### PR TITLE
1.3.1 release, correcting some 1.3.0 troubles

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ From _0.0_ to _10.0_, the values of daySpeed and nightSpeed can be different fro
   - /tm set multilang \[lg_LG]
   - /tm set refreshrate \[tick]
   - /tm set sleep \[true|false] \[all|world]
-  - /tm set speed \[multiplier] \[always|day|night] \[all|world]
+  - /tm set speed \[multiplier] \[all|world]
+  - /tm set speedDay \[multiplier] \[all|world]
+  - /tm set speedNight \[multiplier] \[all|world]
   - /tm set start \[tick|daypart|HH:mm:ss] \[all|world]
   - /tm set sync \[true|false] \[all|world]
   - /tm set time \[tick|daypart|HH:mm:ss] \[all|world]
@@ -112,7 +114,8 @@ From _0.0_ to _10.0_, the values of daySpeed and nightSpeed can be different fro
 [![IMAGE 1. How to Install and Configure the Plugin](http://imageshack.com/a/img924/8047/gxPi0W.png)](https://www.youtube.com/playlist?list=PLPTZNgSLmtr9PxHD_7Y2VFhbSqH8gKBad)
 
 ### COMPATIBILITY
-* v1.3.0: Spigot, Paper and Bukkit - MC 1.4.6 to 1.16.1
+* v1.3.1: Spigot, Paper and Bukkit - MC 1.4.6 to 1.16.4
+* v1.3.0: Spigot, Paper and Bukkit - MC 1.4.6 to 1.16.4
 * v1.2.1: Spigot, Paper and Bukkit - MC 1.4.6 to 1.16.1
 * v1.2.0: Spigot, Paper and Bukkit - MC 1.4.6 to 1.14.3
 * v1.1.1: Spigot, Paper and Bukkit - MC 1.4.6 to 1.13
@@ -127,6 +130,8 @@ From _0.0_ to _10.0_, the values of daySpeed and nightSpeed can be different fro
 * ~~Command: Create a '/tm set initialtick' command.~~
 * ~~Command: Permit 'HH:mm:ss' format for '/ tm set start', '/ tm set time' and '/ tm set initialtick' first argument.~~
 * ~~Command: Make an update message and associated commands.~~
-* ~~Day & Night : A different speed multiplier for the day and the night is still possible, but it will be more difficult than expected because of the 'sync' option. And perhaps it's pretty useless because the '/ tm set speed' command could be easily started automatically at morning and evening.
+* ~~Day & Night : Make a different speed multiplier for the day and the night.~~
+* Sleep: Provide the ability to synchronize a world to a specified one, detecting the coming of a new day after someone has slept.
 * Player Item: Create a custom item (and associated permissions and options) to use the '/now' command.
+* Schedule: Create a schedule allowing commands to be executed at specific times. 
 * Tab completer: Try to improve the current hack that manages the spaces in worlds name.

--- a/lang.yml
+++ b/lang.yml
@@ -25,10 +25,10 @@ languages:
     msg: Please ask an admin to properly define the default language in the lang.yml file then reload the plugin.
     noMsg: There is no day-night cycle in the Nether and the End dimensions.
     dayparts:
-      day: begin at 6.00 am or tick #0
-      dusk: begin at 5.30 pm or tick #11500
+      dawn: begin at 6.00 am or tick #0
+      day: begin at 7.00 am or tick #1000
+      dusk: begin at 6.00 pm or tick #12000
       night: begin at 7.00 pm or tick #13000
-      dawn: begin at 4.30 am or tick #22500
   de_DE:
     prefix: '&e&l[Stunde]'
     msg: Es &e{time}&r in der welt {targetWorld}, das ist {dayPart}.

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: TimeManager
-version: 1.3.0
+version: 1.3.1
 api-version: 1.16
 author: ArVdC
 main: net.vdcraft.arvdc.timemanager.MainTM

--- a/src/net/vdcraft/arvdc/timemanager/CreateSentenceCommand.java
+++ b/src/net/vdcraft/arvdc/timemanager/CreateSentenceCommand.java
@@ -189,7 +189,7 @@ public class CreateSentenceCommand implements TabCompleter {
 							if (verif.toLowerCase().startsWith(args[2].toLowerCase()))
 								outputArgsList.add(verif);
 						}
-					} else if (args[1].equalsIgnoreCase(MainTM.CMD_SET_SPEED) ||args[1].equalsIgnoreCase(MainTM.CMD_SET_D_SPEED) ||args[1].equalsIgnoreCase(MainTM.CMD_SET_N_SPEED)) // Commands '/tm set speed <...>' '/tm set speedDay <...>' '/tm set speedNight <...>'
+					} else if (args[1].equalsIgnoreCase(MainTM.CMD_SET_SPEED) || args[1].equalsIgnoreCase(MainTM.CMD_SET_D_SPEED) || args[1].equalsIgnoreCase(MainTM.CMD_SET_N_SPEED)) // Commands '/tm set speed <...>' '/tm set speedDay <...>' '/tm set speedNight <...>'
 					{
 						for (String verif : tmSpeedArgsList) {
 							if (verif.toLowerCase().startsWith(args[2].toLowerCase()))

--- a/src/net/vdcraft/arvdc/timemanager/MainTM.java
+++ b/src/net/vdcraft/arvdc/timemanager/MainTM.java
@@ -48,8 +48,8 @@ public class MainTM extends JavaPlugin {
 	public static Double decimalOfMcVersion;
 
 	// Enable/Disable debugging
-	public static Boolean debugMode = false; // Final user accessible debug msgs
-	public static Boolean devMode = false; // Displays more verbose debug msgs
+	public static Boolean debugMode = true; // Displays user accessible debug msgs
+	public static Boolean devMode = true; // Displays more verbose debug msgs
 	public static Boolean timerMode = false; // Displays all timers calculations (= ultra-verbose mode)
 
 	// Commands names
@@ -307,11 +307,11 @@ public class MainTM extends JavaPlugin {
 	protected static Double realtimeSpeed = 24.0;
 
 	// DayParts in ticks
-	protected static Integer dayStart = 0;
-	protected static Integer duskStart = 11500;
+	protected static Integer dawnStart = 0;
+	protected static Integer dayStart = 1000;
+	protected static Integer duskStart = 12000;
 	protected static Integer nightStart = 13000;
-	protected static Integer dawnStart = 22500;
-	protected static Integer dayEnd = 24000;
+	protected static Integer mcDayEnd = 24000;
 
 	// Check if schedule is already active
 	protected static Boolean increaseScheduleIsOn = false;
@@ -426,7 +426,7 @@ public class MainTM extends JavaPlugin {
 
 			// #8. Synchronize worlds and create scheduled task for faking the time
 			// stretch/expand
-			WorldSyncHandler.WorldSyncFirst();
+			WorldSyncHandler.firstSync();
 
 			// #9. Confirm activation in console
 			Bukkit.getLogger().info(prefixTM + " " + plEnabledMsg);

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmReload.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmReload.java
@@ -27,13 +27,13 @@ public class TmReload extends MainTM {
 			TmResync.cmdResync(Bukkit.getServer().getConsoleSender(), "all");
 			// Launch scheduler if is inactive
 			if (increaseScheduleIsOn == false) {
-				WorldSpeedHandler.WorldIncreaseSpeed();
+				WorldSpeedHandler.worldIncreaseSpeed();
 			}
 			if (decreaseScheduleIsOn == false) {
-				WorldSpeedHandler.WorldDecreaseSpeed();
+				WorldSpeedHandler.worldDecreaseSpeed();
 			}
 			if (realScheduleIsOn == false) {
-				WorldSpeedHandler.WorldIncreaseSpeed();
+				WorldSpeedHandler.worldIncreaseSpeed();
 			}
 			// 'config.yml is reloaded' notification
 			if (sender instanceof Player) {

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmResync.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmResync.java
@@ -27,7 +27,7 @@ public class TmResync extends MainTM {
 		// Else, if the string argument is a listed world, re-synchronize a single world
 		else if (MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(worldToSet)) {
 			// Do the synchronization
-			WorldSyncHandler.WorldSyncRe(sender, worldToSet);
+			WorldSyncHandler.worldResync(sender, worldToSet);
 		}
 		// Else, return an error and display help message
 		else {

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetInitialTick.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetInitialTick.java
@@ -48,7 +48,7 @@ public class TmSetInitialTick extends MainTM {
 		}
 	    }
 	    // Resynchronization
-	    WorldSyncHandler.WorldSyncRe(sender, "all");
+	    WorldSyncHandler.worldResync(sender, "all");
 
 	} else {
 

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetSleep.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetSleep.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Player;
 
 import net.vdcraft.arvdc.timemanager.MainTM;
 import net.vdcraft.arvdc.timemanager.mainclass.ValuesConverter;
-import net.vdcraft.arvdc.timemanager.mainclass.WorldSpeedHandler;
 
 public class TmSetSleep extends MainTM {
 
@@ -31,7 +30,7 @@ public class TmSetSleep extends MainTM {
 			// Avoid impossible values
 			World w = Bukkit.getWorld(world);
 			long t = w.getTime();
-			String currentSpeed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t)); // TODO ???
+			String currentSpeed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(t));
 			if ((sleepOrNo.equals("true") && (currentSpeed.equals("0.0") || currentSpeed.equals("24.0")))) {
 				// Notifications
 				Bukkit.getLogger().info(prefixTM + " " + worldSleepNoChgMsg + " " + world + "."); // Console final msg (always)

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetSpeed.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetSpeed.java
@@ -34,9 +34,9 @@ public class TmSetSpeed extends MainTM {
 		else if (MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(world)) {
 			// Get the old speed value of this world to correctly resynchronize 24h worlds
 			long t = Bukkit.getWorld(world).getTime();
-			Double oldSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t));
+			Double oldSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(t));
 			// Modify the speed in the config    
-			if (when.equalsIgnoreCase(CMD_SET_SPEED)) {
+			if (when.equalsIgnoreCase(CMD_SET_SPEED) || speed == 24.0) {
 				MainTM.getInstance().getConfig().set(CF_WORLDSLIST + "." + world + "." + CF_D_SPEED, speed);
 				MainTM.getInstance().getConfig().set(CF_WORLDSLIST + "." + world + "." + CF_N_SPEED, speed);
 			} else if (when.equalsIgnoreCase(CMD_SET_D_SPEED)) {
@@ -57,15 +57,15 @@ public class TmSetSpeed extends MainTM {
 			// Launch the good scheduler if is inactive
 			if (speed == realtimeSpeed) {
 				if (realScheduleIsOn == false) {
-					WorldSpeedHandler.WorldRealSpeed();
+					WorldSpeedHandler.worldRealSpeed();
 				}
 			} else if (speed >= 1.0 && speed <= speedMax) {
 				if (increaseScheduleIsOn == false) {
-					WorldSpeedHandler.WorldIncreaseSpeed();
+					WorldSpeedHandler.worldIncreaseSpeed();
 				}
 			} else if (speed > 0.0 && speed < 1.0) {
 				if (decreaseScheduleIsOn == false) {
-					WorldSpeedHandler.WorldDecreaseSpeed();
+					WorldSpeedHandler.worldDecreaseSpeed();
 				}
 			}
 			// Notifications

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetStart.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetStart.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Player;
 
 import net.vdcraft.arvdc.timemanager.MainTM;
 import net.vdcraft.arvdc.timemanager.mainclass.ValuesConverter;
-import net.vdcraft.arvdc.timemanager.mainclass.WorldSpeedHandler;
 import net.vdcraft.arvdc.timemanager.mainclass.WorldSyncHandler;
 
 public class TmSetStart extends MainTM {
@@ -28,9 +27,9 @@ public class TmSetStart extends MainTM {
 		// Else, if the string argument is a listed world, modify a single world
 		} else if (MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(world)) {
 			// Adapt wrong values
-			World w = Bukkit.getWorld(world); //TODO ???
-			long t = w.getTime(); //TODO ???
-			Double currentSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t)); //TODO ???
+			World w = Bukkit.getWorld(world);
+			long t = w.getTime();
+			double currentSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(t));
 			if (currentSpeed == 24.00) {
 				tick = ValuesConverter.returnCorrectUTC(tick) * 1000;
 			} else {
@@ -40,7 +39,7 @@ public class TmSetStart extends MainTM {
 			MainTM.getInstance().getConfig().set(CF_WORLDSLIST + "." + world + "." + CF_START, tick);
 			MainTM.getInstance().saveConfig();
 			// Resync this world
-			WorldSyncHandler.WorldSyncRe(sender, world);
+			WorldSyncHandler.worldResync(sender, world);
 			// Notifications
 			Bukkit.getLogger().info(prefixTM + " " + worldStartChgMsg1 + " " + world + " " + worldStartChgMsg2); // Console final msg (always)
 			if (sender instanceof Player) {

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetSync.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmSetSync.java
@@ -30,9 +30,9 @@ public class TmSetSync extends MainTM {
 	// Else, if the string argument is a listed world, modify a single world
 	else if (MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(world)) {
 	    // Avoid impossible values
-	    World w = Bukkit.getWorld(world); //TODO ???
-	    long t = w.getTime(); //TODO ???
-	    String speed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t)); //TODO ???
+	    World w = Bukkit.getWorld(world);
+	    long t = w.getTime();
+	    String speed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(t));
 	    if ((syncOrNo.equals("true") && speed.equals("0.0")) || (syncOrNo.equals("false") && speed.equals("24.0"))) {
 		// Notifications
 		Bukkit.getLogger().info(prefixTM + " " + worldSyncNoChgMsg + " " + world + "."); // Console final msg (always)
@@ -46,7 +46,7 @@ public class TmSetSync extends MainTM {
 		if (syncOrNo.equals("true")) {
 		    // Start synchronize 1.0 speed worlds
 		    if (speed.equals("1.0") && increaseScheduleIsOn == false) {
-			WorldSpeedHandler.WorldIncreaseSpeed();
+			WorldSpeedHandler.worldIncreaseSpeed();
 		    }
 		    // Avoid players to sleep in a synchronized world
 		    if (MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SLEEP).equals("true")) {

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/LgFileHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/LgFileHandler.java
@@ -18,10 +18,10 @@ public class LgFileHandler extends MainTM {
     private static String defaultPrefix = "&8&l[&6&lTime Manager&8&l]";
     private static String defaultMsg = "Please ask an admin to properly define the default language in the lang.yml file then reload this plugin.";
     private static String defaultNoMsg = "There is no day-night cycle in the Nether and the End dimensions.";
-    private static String defaultDay = "begin at 6.00 am or tick #" + dayStart;
-    private static String defaultDusk = "begin at 5.30 pm or tick #" + duskStart;
+    private static String defaultDay = "begin at 7.00 am or tick #" + dayStart;
+    private static String defaultDusk = "begin at 6.00 pm or tick #" + duskStart;
     private static String defaultNight = "begin at 7.00 pm or tick #" + nightStart;
-    private static String defaultDawn = "begin at 4.30 am or tick #" + dawnStart;
+    private static String defaultDawn = "begin at 6.00 am or tick #" + dawnStart;
 
     /**
      * Activate or reload the language file
@@ -104,7 +104,7 @@ public class LgFileHandler extends MainTM {
 	    }
 	    // Then actualize the 'defaultLang' key from lang.yml file
 	    serverLang = new String(MainTM.getInstance().langConf.getString(CF_DEFAULTLANG));
-	    Bukkit.getServer().getConsoleSender().sendMessage(prefixTM + " " + defLangCheckMsg + " §e" + serverLang + "§b."); // Console log msg
+	    Bukkit.getServer().getConsoleSender().sendMessage(prefixTM + " " + defLangCheckMsg + " §e" + serverLang + "§r."); // Console log msg
 	    // Check if the 'defaultLang' value correspond to an existing language who contains every needed keys
 	    if (debugMode) {
 		Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + availableTranslationsDebugMsg + " §e" + setAnyListFromLang(CF_lANGUAGES)); // Console debug msg

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/ValuesConverter.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/ValuesConverter.java
@@ -65,14 +65,14 @@ public class ValuesConverter extends MainTM {
 	 */
 	public static String getDayPartToDisplay(long tick) {
 		String wichPart = new String();
-		if (tick >= dayStart && tick < duskStart) {
+		if (tick >= dawnStart && tick < dayStart) {
+			wichPart = "dawn";
+		} else if (tick >= dayStart && tick < duskStart) {
 			wichPart = "day";
 		} else if (tick >= duskStart && tick < nightStart) {
 			wichPart = "dusk";
-		} else if (tick >= nightStart && tick < dawnStart) {
+		} else if (tick >= nightStart && tick < mcDayEnd) {
 			wichPart = "night";
-		} else if (tick >= dawnStart && tick < dayEnd) {
-			wichPart = "dawn";
 		} else {
 			return null;
 		}
@@ -85,17 +85,17 @@ public class ValuesConverter extends MainTM {
 	 */
 	public static String returnTickFromStringValue(String tick) {
 		if (tick.equalsIgnoreCase("day")) {
-			tick = "0";
+			tick = "1000";
 		} else if (tick.equalsIgnoreCase("midday") || tick.equalsIgnoreCase("noon")) {
 			tick = "6000";
 		} else if (tick.equalsIgnoreCase("dusk") || tick.equalsIgnoreCase("sunset") || tick.equalsIgnoreCase("evening")) {
-			tick = "11500";
+			tick = "1200";
 		} else if (tick.equalsIgnoreCase("night")) {
 			tick = "13000";
 		} else if (tick.equalsIgnoreCase("midnight")) {
 			tick = "18000";
 		} else if (tick.equalsIgnoreCase("dawn") || tick.equalsIgnoreCase("sunrise") || tick.equalsIgnoreCase("morning")) {
-			tick = "22500";
+			tick = "23000";
 		}
 		return tick;
 	}
@@ -279,6 +279,19 @@ public class ValuesConverter extends MainTM {
 	}
 
 	/**
+	 *  Get the correct speed value's name (daySpeed or nightSpeed) for a given tick (returns a string)
+	 */
+	public static String wichSpeedParam(long tick) {
+		String speedParam;
+		if (ValuesConverter.getDayPartToDisplay(tick).equalsIgnoreCase("day") || ValuesConverter.getDayPartToDisplay(tick).equalsIgnoreCase("dusk")) {	    
+			speedParam = CF_D_SPEED;	
+		} else {
+			speedParam = CF_N_SPEED;
+		}
+		return speedParam;
+	}
+
+	/**
 	 * Restrain refresh rate (modifies the configuration)
 	 */
 	public static void restrainRate() {
@@ -312,7 +325,7 @@ public class ValuesConverter extends MainTM {
 	public static void restrainStart(String world) {
 		long t = Bukkit.getWorld(world).getTime();
 		String time = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_START);
-		String currentSpeed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t));
+		String currentSpeed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + wichSpeedParam(t));
 		time = ValuesConverter.returnTickFromStringValue(time); // Check if value is a part of the day
 		long tick;
 		try { // Check if value is a long
@@ -382,7 +395,7 @@ public class ValuesConverter extends MainTM {
 	 */
 	public static void restrainSync(String world, Double oldSpeed) {
 		long t = Bukkit.getWorld(world).getTime();
-		Double currentSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t));
+		Double currentSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + wichSpeedParam(t));
 		if (currentSpeed == 24.0) { // new speed is 24
 			MainTM.getInstance().getConfig().set(CF_WORLDSLIST + "." + world + "." + CF_SYNC, "true");
 			if (debugMode) Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + syncAdjustTrueDebugMsg + " §e" + world + "§b."); // Console debug msg
@@ -401,7 +414,7 @@ public class ValuesConverter extends MainTM {
 	 */
 	public static void restrainSleep(String world) {
 		long t = Bukkit.getWorld(world).getTime();
-		String currentSpeed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t));
+		String currentSpeed = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + wichSpeedParam(t));
 		if (currentSpeed.equalsIgnoreCase("0.0") || currentSpeed.contains("24")) {
 			MainTM.getInstance().getConfig().set(CF_WORLDSLIST + "." + world + "." + CF_SLEEP, "false");
 			if (debugMode) Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + sleepAdjustFalseDebugMsg + " §e" + world + "§b."); // Console debug msg

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/WorldDoDaylightCycleHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/WorldDoDaylightCycleHandler.java
@@ -23,7 +23,7 @@ public class WorldDoDaylightCycleHandler extends MainTM {
 		} else {
 			World w = Bukkit.getWorld(worldToSet);
 			long t = w.getTime();
-			double speedModifier = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST +"." + worldToSet + "." + WorldSpeedHandler.wichSpeedParam(t)); //TODO ???
+			double speedModifier = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST +"." + worldToSet + "." + ValuesConverter.wichSpeedParam(t));
 			if (speedModifier == realtimeSpeed || speedModifier < 1.0) {
 				if (decimalOfMcVersion < 13.0) {
 					w.setGameRuleValue("doDaylightCycle", "false");

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/WorldSleepHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/WorldSleepHandler.java
@@ -24,7 +24,7 @@ public class WorldSleepHandler implements Listener {
 		World w = e.getBed().getWorld();
 		String world = w.getName();
 		long t = w.getTime();
-		double speedModifier = MainTM.getInstance().getConfig().getDouble(MainTM.CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(t)); //TODO ???
+		double speedModifier = MainTM.getInstance().getConfig().getDouble(MainTM.CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(t));
 		// Ignore: Nether and Ender worlds AND worlds with a fixed time (speed 0 or 24)
 		if (!(world.contains("_nether")) && !(world.contains("_the_end")) && !(speedModifier == 24.00) && !(speedModifier == 0)) {
 			// Delay the doDaylightCycle gamerule change
@@ -53,12 +53,8 @@ public class WorldSleepHandler implements Listener {
 						}
 						// Do something only if the value contradicts the current settings
 						if ((isSleepPermited.equals(false) && speedModifier >= 1.0) || (isSleepPermited.equals(true) && speedModifier < 1.0)) {
-
-							if (MainTM.decimalOfMcVersion < 13.0) {
-								w.setGameRuleValue("doDaylightCycle", isSleepPermited.toString());
-							} else {
-								w.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, isSleepPermited);
-							}
+							if (MainTM.decimalOfMcVersion < 13.0) w.setGameRuleValue("doDaylightCycle", isSleepPermited.toString());
+							else w.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, isSleepPermited);
 							restoreDayCycle(p, w.getName());
 						}
 					}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/WorldSpeedHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/WorldSpeedHandler.java
@@ -10,7 +10,8 @@ public class WorldSpeedHandler extends MainTM {
 	/**
 	 * Increase worlds speed to a custom rate with an auto cancel/repeat capable scheduler
 	 */
-	public static void WorldIncreaseSpeed() {
+	public static void worldIncreaseSpeed() {
+		
 		increaseScheduleIsOn = true;
 		refreshRateLong = MainTM.getInstance().getConfig().getLong(CF_REFRESHRATE);
 
@@ -18,61 +19,75 @@ public class WorldSpeedHandler extends MainTM {
 		speedSheduler.scheduleSyncDelayedTask(MainTM.getInstance(), new Runnable() {
 			@Override
 			public void run() {
-				boolean loopMore = false;
+
+				// By default, don't launch the loop again
+				boolean loopAgain = false;
+
 				for (String world : MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false)) {
 					// Get the current time of the world
 					long currentTime = Bukkit.getWorld(world).getTime();
 					// Get the current 'speed' value
-					double speed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + wichSpeedParam(currentTime)); // Get the current speed of the world
+					double speed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(currentTime));
+					// Get the current 'sync' value
+					String sync = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SYNC);
+
 					long newTime = 0L;
-					if (speed >= 1.0 && speed <= speedMax && speed != 24.00) { // Only treat worlds with normal or increased timers
+
+					// Only treat worlds with normal or increased timers
+					if (speed >= 1.0 && speed <= speedMax) {
+
 						// #A. Synchronized time calculation
-						if (MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SYNC).equalsIgnoreCase("true")) {
-							loopMore = true;
+						if (sync.equalsIgnoreCase("true")) {
 							// Get the current server time
 							long currentServerTick = ValuesConverter.returnServerTick();
 							// Get the world's 'start' value
 							long startAtTickNb = (MainTM.getInstance().getConfig().getLong(CF_WORLDSLIST + "." + world + "." + CF_START));
 							// Get the world's speed value at server start
-							double speedAtStart = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(startAtTickNb));
+							double speedAtStart = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(startAtTickNb));
 							// Get the world's 'daySpeed' value
 							double daySpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + CF_D_SPEED);
 							// Get the world's 'nightSpeed' value
 							double nightSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + CF_N_SPEED);
 							// Get the total server's elapsed time
 							long elapsedServerTime = currentServerTick - initialTick;
+
 							// #A.1. If it is a (daySpeed == nightSpeed) world ...
 							if (daySpeed == nightSpeed) { // Next tick = Start at #tick + (Elapsed time * speed modifier)
 								newTime = (long) ((startAtTickNb + (elapsedServerTime * speed)) % 24000);
 								if (timerMode) {
-									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " Calculation of " + actualTimeVar + ":");
+									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " Calculation of " + actualTimeVar + " for world §e" + world + "§b:");
 									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + elapsedTimeCalculation + " = (§8" + currentServerTick + " §b- §7" + initialTick + "§b) % §624000 §b= §d" + ((currentServerTick - initialTick) % 24000) + " §brestrained to one day = §d" + ValuesConverter.returnCorrectTicks(((currentServerTick % 24000) - (initialTick % 24000)))); // Console debug msg
 									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + adjustedElapsedTimeCalculation + " = §d" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick % 24000))) + " §b* §a" + speed + " §b= §5" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * speed)))); // Console debug msg
 									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + actualTimeCalculation + " = §e" + startAtTickNb + " §b+ §5" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * speed) + " §b= §c" + (startAtTickNb + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * speed)) + " §brestrained to one day = §ctick #" + ValuesConverter.returnCorrectTicks(newTime)); // Console debug msg
 								}
-								// #A.2. ... or if it is a (daySpeed != nightSpeed) world
+
+							// #A.2. ... or if it is a (daySpeed != nightSpeed) world
 							} else {
-								newTime = worldWithDifferentSpeedNewTime(world, startAtTickNb, elapsedServerTime, currentServerTick, speedAtStart, daySpeed, nightSpeed, false); // TODO
+								newTime = WorldSyncHandler.differentSpeedsNewTime(world, startAtTickNb, elapsedServerTime, currentServerTick, speedAtStart, daySpeed, nightSpeed, false);
 							}
-							// #B. Normal time calculation
+
+						// #B. Normal time calculation
 						} else if (speed > 1.0) { // Only treat worlds with increased timers
-							loopMore = true;
 							long modifTime = (long) Math.ceil(refreshRateInt * speed);
 							newTime = currentTime + modifTime - refreshRateLong;
 						}
-						if (MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SYNC).equalsIgnoreCase("true") || speed > 1.0) {
-							// Restrain too big and too small values
-							newTime = ValuesConverter.returnCorrectTicks(newTime);
-							// Change world's timer
-							Bukkit.getWorld(world).setTime(newTime);
-						}
+						// Restrain too big and too small values
+						newTime = ValuesConverter.returnCorrectTicks(newTime);
+						// Change world's timer (not for 1.0 unsynchronized worlds)
+						if ((speed != 1.0) || ((speed == 1.0) && (sync.equalsIgnoreCase("true")))) Bukkit.getWorld(world).setTime(newTime);
+						// Check if there is a new 'speed' value
+						double newSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(newTime));
+						// If any world is concerned, launch the loop again
+						if (newSpeed > 1.0 || (newSpeed == 1 && sync.equalsIgnoreCase("true"))) loopAgain = true;
+						// Change the doDaylightCycle gamerule if it is needed				
+						if (newSpeed < 1.0) WorldDoDaylightCycleHandler.doDaylightSet(world);
+						// Activate the decrease schedule if it is needed and not already activated
+						if (decreaseScheduleIsOn == false && (newSpeed < 1.0 && newSpeed > 0.0)) worldDecreaseSpeed();
 					}
 				}
-				if (loopMore == true) {
-					WorldIncreaseSpeed();
-				} else {
-					increaseScheduleIsOn = false;
-				}
+				// Permit or not to launch the loop again
+				if (loopAgain == true) worldIncreaseSpeed();
+				else increaseScheduleIsOn = false;
 			}
 		}, refreshRateLong);
 	}
@@ -80,8 +95,8 @@ public class WorldSpeedHandler extends MainTM {
 	/**
 	 * Decrease worlds speed to a custom rate with an auto cancel/repeat capable scheduler
 	 */
-	public static void WorldDecreaseSpeed() {
-		
+	public static void worldDecreaseSpeed() {
+
 		decreaseScheduleIsOn = true;
 		refreshRateLong = MainTM.getInstance().getConfig().getLong(CF_REFRESHRATE);
 
@@ -89,42 +104,53 @@ public class WorldSpeedHandler extends MainTM {
 		speedSheduler.scheduleSyncDelayedTask(MainTM.getInstance(), new Runnable() {
 			@Override
 			public void run() {
-				boolean loopMore = false;
+
+				// By default, don't launch the loop again
+				boolean loopAgain = false;
+
 				for (String world : MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false)) {
 					// Get the current time of the world
 					long currentTime = Bukkit.getWorld(world).getTime();
 					// Get the current 'speed' value
-					double speed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + wichSpeedParam(currentTime));
-					long newTime;
+					double speed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(currentTime));
+					// Get the current 'sync' value
+					String sync = MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SYNC);
+
+					long newTime = 0L;
+
 					// Only treat worlds with decreased timers
 					if (speed > 0.0 && speed < 1.0) {
-						// By default, launch the loop again
-						loopMore = true;
-						
+
 						// #A. Synchronized time calculation
-						if (MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SYNC).equalsIgnoreCase("true")) {
+						if (sync.equalsIgnoreCase("true")) {
 							// Get the current server time
 							long currentServerTick = ValuesConverter.returnServerTick();
 							// Get the world's 'start' value
 							long startAtTickNb = (MainTM.getInstance().getConfig().getLong(CF_WORLDSLIST + "." + world + "." + CF_START));
 							// Get the world's speed value at server start
-							double speedAtStart = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + WorldSpeedHandler.wichSpeedParam(startAtTickNb));
+							double speedAtStart = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(startAtTickNb));
 							// Get the world's 'daySpeed' value
 							double daySpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + CF_D_SPEED);
 							// Get the world's 'nightSpeed' value
 							double nightSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + CF_N_SPEED);
 							// Get the total server's elapsed time
 							long elapsedServerTime = currentServerTick - initialTick;
-							
-							// #A.1. if it is a (daySpeed == nightSpeed) world
+
+							// #A.1. If it is a (daySpeed == nightSpeed) world ...
 							if (daySpeed == nightSpeed) { // Next tick = Start at #tick + (Elapsed time * speed modifier)
 								newTime = (long) ((startAtTickNb + (elapsedServerTime * speed)) % 24000);
-							
-								// #A.2. ... or if it is a (daySpeed != nightSpeed) world 
+								if (timerMode) {
+									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " Calculation of " + actualTimeVar + " for world §e" + world + "§b:");
+									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + elapsedTimeCalculation + " = (§8" + currentServerTick + " §b- §7" + initialTick + "§b) % §624000 §b= §d" + ((currentServerTick - initialTick) % 24000) + " §brestrained to one day = §d" + ValuesConverter.returnCorrectTicks(((currentServerTick % 24000) - (initialTick % 24000)))); // Console debug msg
+									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + adjustedElapsedTimeCalculation + " = §d" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick % 24000))) + " §b* §a" + speed + " §b= §5" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * speed)))); // Console debug msg
+									Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + actualTimeCalculation + " = §e" + startAtTickNb + " §b+ §5" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * speed) + " §b= §c" + (startAtTickNb + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * speed)) + " §brestrained to one day = §ctick #" + ValuesConverter.returnCorrectTicks(newTime)); // Console debug msg
+								}
+
+							// #A.2. ... or if it is a (daySpeed != nightSpeed) world 
 							} else {
-								newTime = worldWithDifferentSpeedNewTime(world, startAtTickNb, elapsedServerTime, currentServerTick, speedAtStart, daySpeed, nightSpeed, false);
+								newTime = WorldSyncHandler.differentSpeedsNewTime(world, startAtTickNb, elapsedServerTime, currentServerTick, speedAtStart, daySpeed, nightSpeed, false);
 							}
-							
+
 						// #B. Normal time calculation
 						} else {
 							// Try to compensate for missing ticks due to decimals
@@ -145,18 +171,26 @@ public class WorldSpeedHandler extends MainTM {
 							long modifTime = (long) Math.floor((refreshRateInt * speed));
 							newTime = currentTime + modifTime + randomTicks;
 						}
-						
+
 						// Restrain too big and too small values
 						newTime = ValuesConverter.returnCorrectTicks(newTime);
 						// Change world's timer
 						Bukkit.getWorld(world).setTime(newTime);
+						// Check if there is a new 'speed' value
+						double newSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(newTime));						
+						// If any world is concerned, launch the loop again
+						if (newSpeed < 1.0 && newSpeed > 0.0) loopAgain = true;
+						// Change the doDaylightCycle gamerule if it is needed
+						if (newSpeed >= 1.0) WorldDoDaylightCycleHandler.doDaylightSet(world);
+						// Activate the increase schedule if it is needed and not already activated
+						if (increaseScheduleIsOn == false && ((MainTM.getInstance().getConfig().getString(CF_WORLDSLIST + "." + world + "." + CF_SYNC).equalsIgnoreCase("true") && newSpeed == 1.0) || newSpeed > 1.0)) {
+							worldIncreaseSpeed();
+						}
 					}
 				}
-				if (loopMore == true) {
-					WorldDecreaseSpeed();
-				} else {
-					decreaseScheduleIsOn = false;
-				}
+				// Permit or not to launch the loop again
+				if (loopAgain == true) worldDecreaseSpeed();
+				else decreaseScheduleIsOn = false;
 			}
 		}, refreshRateLong);
 	}
@@ -164,19 +198,23 @@ public class WorldSpeedHandler extends MainTM {
 	/**
 	 * Modify worlds speed to real time speed with an auto cancel/repeat capable scheduler
 	 */
-	public static void WorldRealSpeed() {
+	public static void worldRealSpeed() {
+		
 		realScheduleIsOn = true;
+		
 		BukkitScheduler realSpeedSheduler = MainTM.getInstance().getServer().getScheduler();
 		realSpeedSheduler.scheduleSyncDelayedTask(MainTM.getInstance(), new Runnable() {
 			@Override
 			public void run() {
-				boolean loopMore = false;
+				
+				// By default, don't launch the loop again
+				boolean loopAgain = false;
+				
 				for (String world : MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false)) {
 					long t = Bukkit.getWorld(world).getTime();
-					Double speed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + wichSpeedParam(t));
+					Double speed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(t));
 					long worldStartAt = MainTM.getInstance().getConfig().getLong(CF_WORLDSLIST + "." + world + "." + CF_START);
-					if (speed == 24.00) { // Only treat worlds with a '24.0' timers
-						loopMore = true;
+					if (speed == 24.00) { // Only treat worlds with a '24' timer
 						// Get the current server tick
 						long currentServerTick = ValuesConverter.returnServerTick();
 						long newTime = (currentServerTick / 72L) + (worldStartAt - 6000L); // -6000 cause a mc's day start at 6:00
@@ -184,92 +222,15 @@ public class WorldSpeedHandler extends MainTM {
 						newTime = ValuesConverter.returnCorrectTicks(newTime);
 						// Change world's timer
 						Bukkit.getWorld(world).setTime(newTime);
+						// If any world is concerned, launch the loop again
+						loopAgain = true;
 					}
 				}
-				if (loopMore == true) {
-					WorldRealSpeed();
-				} else {
-					realScheduleIsOn = false;
-				}
+				// Permit or not to launch the loop again
+				if (loopAgain == true) worldRealSpeed();
+				else realScheduleIsOn = false;
 			}
 		}, 72L);
-	}
-
-	/**
-	 * Calculate world time when daySpeed and nightSpeed are not equal (returns a long)
-	 */
-	public static long worldWithDifferentSpeedNewTime(String world, long startAtTickNb, long elapsedServerTime, long currentServerTick, double speedAtStart, double daySpeed, double nightSpeed, boolean displayMsg) {
-		// Get the required server time for spending a day or a night or both in the target world
-		long worldDayTimeInServerTicks = (long) (12000 / daySpeed);
-		long worldNightTimeInServerTicks = (long) (12000 / nightSpeed);
-		long worldFullTimeInServerTicks = worldDayTimeInServerTicks + worldNightTimeInServerTicks;
-		// Use two variables for speed, depending of day/night starting time
-		double firstSpeed = daySpeed; // day
-		double secondSpeed = daySpeed;
-		long secondCycleDuration = worldNightTimeInServerTicks;
-		long halfDaylightCycle = 12000;
-		if (speedAtStart == nightSpeed) { // night
-			firstSpeed = nightSpeed;	
-			secondSpeed = daySpeed;
-			secondCycleDuration = worldDayTimeInServerTicks;
-			halfDaylightCycle = 24000;	    
-		}
-		// Use a clone of elapsedTime to subtract the number of ticks remaining
-		long serverRemainingTime = elapsedServerTime;
-		long newTime;
-		// #1. If elapsed time is smaller than an half day minus the startTime (= no day/night change) ...
-		if ((elapsedServerTime * firstSpeed) < (12000 - startAtTickNb)) {
-			// #1.A. Use the classic easy formula
-			newTime = (long) (startAtTickNb + (elapsedServerTime * firstSpeed));
-			// #1.B. Debug Msg
-			if (debugMode && displayMsg == true) {
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " Resync: Calculation of " + actualTimeVar + " for world §e" + world + "§b:");
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + elapsedTimeCalculation + " = (§8" + currentServerTick + " §b- §7" + initialTick + "§b) % §624000 §b= §d" + ((currentServerTick - initialTick) % 24000) + " §brestrained to one day = §d" + ValuesConverter.returnCorrectTicks(((currentServerTick % 24000) - (initialTick % 24000)))); // Console debug msg
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + adjustedElapsedTimeCalculation + " = §d" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick % 24000))) + " §b* §a" + firstSpeed + " §b= §5" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * firstSpeed)))); // Console debug msg
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + actualTimeCalculation + " = §e" + startAtTickNb + " §b+ §5" + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * firstSpeed) + " §b= §c" + (startAtTickNb + ((ValuesConverter.returnCorrectTicks(((currentServerTick - initialTick) % 24000))) * firstSpeed)) + " §brestrained to one day = §ctick #" + ValuesConverter.returnCorrectTicks(newTime)); // Console debug msg
-			}
-		// #2. ... or if elapsed time is bigger than an half-day (= a least one day/night change)
-		} else {
-			// #2.A. Count the 1st cycle (<= half-day)
-			newTime = halfDaylightCycle; // (+) 1st cycle
-			serverRemainingTime = (long) (serverRemainingTime - ((halfDaylightCycle - startAtTickNb) / firstSpeed)); // (-) 1st cycle
-			// #2.B. Count down all full-days
-			if (serverRemainingTime > worldFullTimeInServerTicks) {
-				serverRemainingTime = (long) (serverRemainingTime % (worldFullTimeInServerTicks)); // (-) all full daylightCycles
-			}
-			// #2.C. Count an eventual complete day or night cycle ...
-			if (serverRemainingTime > secondCycleDuration) {
-				newTime = (long) (newTime + 12000); // (+) a complete day or night cycle
-				serverRemainingTime = serverRemainingTime - secondCycleDuration; // (-) a complete day or night cycle
-
-				// #2.C.1. ... and finally count the rest of the last day or night cycle
-				newTime = (long) (newTime + (serverRemainingTime * firstSpeed)); // (+) last partial 
-
-				// #2.C.2. ... or directly count the rest of the last day or night cycle
-			} else {
-				newTime = (long) (newTime + serverRemainingTime * secondSpeed); // (+) last partial cycle
-			}
-			// #2.D. Debug Msg
-			if (debugMode && displayMsg) {
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " Resync: Calculation of " + actualTimeVar + " for world §e" + world + "§b:");
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + serverRemainingTimeVar + " = (" + elapsedTimeVar + " - ((" + halfDaylightCycleVar + " - " + worldStartAtVar + ") / (" + daySpeedModifierVar + " || " + nightSpeedModifierVar + "))) % ((§f12000 §b/ " + daySpeedModifierVar + ") + (§f12000 §b/ " + nightSpeedModifierVar + "))) - (§f0 §b|| §f12000§b) / (" + daySpeedModifierVar + " || " + nightSpeedModifierVar + ")) = §5" + serverRemainingTime); // Console debug msg
-				Bukkit.getServer().getConsoleSender().sendMessage(prefixDebugMode + " " + actualTimeVar + " = " + halfDaylightCycleVar + " + §b|(§f0 §b|| §f12000§b) + (" + serverRemainingTimeVar + " * (" + daySpeedModifierVar + " || " + nightSpeedModifierVar + ")) = §c" + "§ctick #" + newTime); // Console debug msg
-			}
-		} 
-		return newTime;
-	}
-
-	/**
-	 * Return a string with the correct speed multiplier (daySpeed or nightSpeed)
-	 */
-	public static String wichSpeedParam(long tick) {
-		String speedParam;
-		if (ValuesConverter.getDayPartToDisplay(tick).equalsIgnoreCase("day") || ValuesConverter.getDayPartToDisplay(tick).equalsIgnoreCase("dusk")) {	    
-			speedParam = CF_D_SPEED;	
-		} else {
-			speedParam = CF_N_SPEED;
-		}
-		return speedParam;
 	}
 
 };


### PR DESCRIPTION
- Fixed the 6am/7pm bug, which froze worlds, when going from decelerated
to normal speed, due to the doDaylightCycle gamerule not being updated.
So issue #6 is now closed.
- From now on the plugin uses a better distribution of the parts of the
day(0-dawn, 1000-day, 12000-night, 13000-dusk)
- Using commands "/tm set speedDay" or "/tm set speedNight" with a value
of "24.00" will now change both speeds in the configuration.
- Fixed timers of synchronized worlds which, on startup, did not display
the correct times.