### PR TITLE
Bump 1.12.0: bed/sleep/worldlist/lang fixes

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: TimeManager
-version: 1.12.0
+version: 1.12.1
 api-version: '1.21'
 authors: [ArVdC]
 main: net.vdcraft.arvdc.timemanager.MainTM

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: TimeManager
-version: 1.11.0
+version: 1.12.0
 api-version: '1.21'
 authors: [ArVdC]
 main: net.vdcraft.arvdc.timemanager.MainTM

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.vdcraft.arvdc</groupId>
 	<artifactId>TimeManager</artifactId>
-	<version>1.11.0</version>
+	<version>1.12.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.vdcraft.arvdc</groupId>
 	<artifactId>TimeManager</artifactId>
-	<version>1.12.0</version>
+	<version>1.12.1</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/net/vdcraft/arvdc/timemanager/MainTM.java
+++ b/src/net/vdcraft/arvdc/timemanager/MainTM.java
@@ -192,6 +192,7 @@ public class MainTM extends JavaPlugin {
 	public static final String LG_STAY = "stay";
 	public static final String LG_FADEOUT = "fadeOut";
 	protected static final String LG_DEFAULT = "default";
+	protected static final String LG_FALLBACK_LANG = "en_US";
 	protected static final String LG_PREFIX = "prefix";
 	protected static final String LG_MSG = "msg";
 	protected static final String LG_NETHERMSG = "netherMsg";

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/LgFileHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/LgFileHandler.java
@@ -199,8 +199,9 @@ public class LgFileHandler extends MainTM {
 	private static void checkDefLang() {
 		if (!MainTM.getInstance().langConf.getKeys(false).contains(LG_DEFAULTLANG)) {
 			restoreDefLang();
-		} else { // Else, if 'defaultLang' key exists but is void set it to the fallback language
-			if (MainTM.getInstance().langConf.getString(LG_DEFAULTLANG).equals("")) {
+		} else { // Else, if 'defaultLang' key is void or still points to the placeholder, set it to the fallback language
+			String current = MainTM.getInstance().langConf.getString(LG_DEFAULTLANG);
+			if (current == null || current.equals("") || current.equalsIgnoreCase(LG_DEFAULT)) {
 				MainTM.getInstance().langConf.set(LG_DEFAULTLANG, pickFallbackLang());
 			}
 			// Then actualize the 'defaultLang' key from lang.yml file

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/LgFileHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/LgFileHandler.java
@@ -195,13 +195,13 @@ public class LgFileHandler extends MainTM {
 	/**
 	 * Check 'defaultLang' integrity in lang.yml
 	 */
-	// Check if 'defaultLang' key exists in yaml, if not create it and set it to default
+	// Check if 'defaultLang' key exists in yaml, if not create it and set it to a usable fallback
 	private static void checkDefLang() {
 		if (!MainTM.getInstance().langConf.getKeys(false).contains(LG_DEFAULTLANG)) {
 			restoreDefLang();
-		} else { // Else, if 'defaultLang' key exists but is void set it to default
+		} else { // Else, if 'defaultLang' key exists but is void set it to the fallback language
 			if (MainTM.getInstance().langConf.getString(LG_DEFAULTLANG).equals("")) {
-				MainTM.getInstance().langConf.set(LG_DEFAULTLANG, LG_DEFAULT);
+				MainTM.getInstance().langConf.set(LG_DEFAULTLANG, pickFallbackLang());
 			}
 			// Then actualize the 'defaultLang' key from lang.yml file
 			serverLang = new String(MainTM.getInstance().langConf.getString(LG_DEFAULTLANG));
@@ -266,8 +266,18 @@ public class LgFileHandler extends MainTM {
 	 */
 	private static void restoreDefLang() {
 		MsgHandler.colorMsg("§e" + serverLang + "§r " + defLangResetMsg); // Console log msg
-		MainTM.getInstance().langConf.set(LG_DEFAULTLANG, LG_DEFAULT);
+		MainTM.getInstance().langConf.set(LG_DEFAULTLANG, pickFallbackLang());
 		serverLang = new String(MainTM.getInstance().langConf.getString(LG_DEFAULTLANG));
+	}
+
+	/**
+	 * Picks the safest fallback language: prefer LG_FALLBACK_LANG (en_US) when
+	 * present in lang.yml, otherwise fall back to the placeholder LG_DEFAULT.
+	 */
+	private static String pickFallbackLang() {
+		org.bukkit.configuration.ConfigurationSection langs = MainTM.getInstance().langConf.getConfigurationSection(LG_LANGUAGES);
+		if (langs != null && langs.getKeys(false).contains(LG_FALLBACK_LANG)) return LG_FALLBACK_LANG;
+		return LG_DEFAULT;
 	}
 
 	/**

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/SleepHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/SleepHandler.java
@@ -63,8 +63,7 @@ public class SleepHandler implements Listener {
 		if (MainTM.serverMcVersion >= MainTM.reqMcVForWorldIsBedWorks) {
 			if (!w.isBedWorks()) {
 				MsgHandler.debugMsg(MainTM.sleepProcessImpossibleDebugMsg + " " + ChatColor.YELLOW + world + ChatColor.AQUA + ". " + player + MainTM.sleepProcessEndsDebugMsg); // Console debug msg
-				e.setCancelled(true);
-				return; // If it's a world where sleep is impossible (Nether, etc.)
+				return; // Vanilla handles bed-explosion in worlds where sleep is impossible (Nether, End)
 			}
 		}
 		if (sync != null && sync.equalsIgnoreCase(MainTM.ARG_TRUE)) {
@@ -217,8 +216,8 @@ public class SleepHandler implements Listener {
 			String LegacyPercent = MainTM.getInstance().getConfig().getString(MainTM.CF_WORLDSLIST + "." + w.getName() + "." + MainTM.CF_NIGHTSKIP_LEGACYPERCENTAGE);
 			spPercent = Integer.parseInt(LegacyPercent);		
 		} else spPercent = w.getGameRuleValue(GameRule.PLAYERS_SLEEPING_PERCENTAGE);
-		if (debugMsg) MsgHandler.debugMsg(spNb / rpNb * 100 + "% of relevant players are sleeping now (" + spNb + "/" + rpNb + ") and " + spPercent + "% is required."); // Console debug msg
-		if (spNb >= rpNb * (spPercent / 100)) return true; // If the percentage is reached, return true
+		if (debugMsg) MsgHandler.debugMsg((rpNb == 0 ? 0 : spNb * 100 / rpNb) + "% of relevant players are sleeping now (" + spNb + "/" + rpNb + ") and " + spPercent + "% is required."); // Console debug msg
+		if (spNb * 100 >= rpNb * spPercent) return true; // If the percentage is reached, return true
 		else return false;
 	}
 	
@@ -353,9 +352,9 @@ public class SleepHandler implements Listener {
         if (bedBlock.getType().toString().endsWith("_BED")){
         	Directional blockDirection = (Directional) bedBlock.getBlockData();
         	facing = blockDirection.getFacing().toString();
-        } else facing = "UNKNOW";
+        } else facing = "UNKNOWN";
     return facing;
-	}	
+	}
 	
 	/**
 	 * Adjusts particles position depending on the orientation of the bed
@@ -389,7 +388,7 @@ public class SleepHandler implements Listener {
                 adjustedLoc.add(-1.5, 0.5, 0.0);
                 adjustedLoc.setYaw(270f);
                 break;
-            case "UNKNOW":   	
+            case "UNKNOWN":
                 adjustedLoc.add(0.0, 0.5, 0.0);
                 adjustedLoc.setYaw(0f);
                 break;
@@ -406,19 +405,19 @@ public class SleepHandler implements Listener {
 		default:
 		case 4 :
 			p.spawnParticle(Particle.CLOUD, loc, 10, 1, 1, 1);
-			MsgHandler.errorMsg("100 " + Particle.CLOUD + " was displayed at location : " + loc);
+			MsgHandler.debugMsg("10 " + Particle.CLOUD + " was displayed at location : " + loc);
 			break;
 		case 3 :
 			p.spawnParticle(Particle.CLOUD, loc, 50, 1, 1, 1);
-			MsgHandler.errorMsg("50 " + Particle.CLOUD + " was displayed at location : " + loc);
+			MsgHandler.debugMsg("50 " + Particle.CLOUD + " was displayed at location : " + loc);
 			break;
 		case 2 :
 			p.spawnParticle(Particle.CLOUD, loc, 100, 1, 1, 1);
-			MsgHandler.errorMsg("10 " + Particle.CLOUD + " was displayed at location : " + loc);
+			MsgHandler.debugMsg("100 " + Particle.CLOUD + " was displayed at location : " + loc);
 			break;
 		case 1 :
 			p.spawnParticle(Particle.CLOUD, loc, 500, 1, 1, 1);
-			MsgHandler.errorMsg("1 " + Particle.CLOUD + " was displayed at location : " + loc);
+			MsgHandler.debugMsg("500 " + Particle.CLOUD + " was displayed at location : " + loc);
 			break;
 		}
 	}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/WorldListHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/WorldListHandler.java
@@ -1,5 +1,6 @@
 package net.vdcraft.arvdc.timemanager.mainclass;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.Bukkit;
@@ -84,29 +85,23 @@ public class WorldListHandler implements Listener {
 		
 		// #4. Remove 'Example' and inexistent worlds if they are present in the config list
 		List<World> loadedWorlds = Bukkit.getServer().getWorlds();
+		List<String> loadedWorldsNames = new ArrayList<String>();
+		for (World lw : loadedWorlds) loadedWorldsNames.add(lw.getName());
 		MsgHandler.debugMsg(MainTM.refrehWorldsListDebugMsg); // Console debug msg
 		MsgHandler.debugMsg(MainTM.worldsRawListDebugMsg + " §e" + loadedWorlds); // Console debug msg
-		String loadedWorldsNames = "" + loadedWorlds;
-		loadedWorldsNames = loadedWorldsNames.replace("},", ",").replace("CraftWorld{name=", "");
-		loadedWorldsNames = loadedWorldsNames.substring(0, loadedWorldsNames.length() - 2);
-		loadedWorldsNames = loadedWorldsNames.substring(1, loadedWorldsNames.length());
-		MsgHandler.debugMsg(MainTM.worldsFormatListDebugMsg + " [" + loadedWorldsNames + "]"); // Console debug msg
+		MsgHandler.debugMsg(MainTM.worldsFormatListDebugMsg + " " + loadedWorldsNames); // Console debug msg
 		MsgHandler.debugMsg(MainTM.worldsCfgListDebugMsg + " " + CfgFileHandler.setAnyListFromConfig(MainTM.CF_WORLDSLIST)); // Console debug msg
-		for (String w : MainTM.getInstance().getConfig().getConfigurationSection(MainTM.CF_WORLDSLIST).getKeys(false)) {
-			Boolean eraseWorld = false;
+		List<String> configuredWorlds = new ArrayList<String>(MainTM.getInstance().getConfig().getConfigurationSection(MainTM.CF_WORLDSLIST).getKeys(false));
+		for (String w : configuredWorlds) {
 			if (w.equalsIgnoreCase(example) || !loadedWorldsNames.contains(w)) {
-				eraseWorld = true;
-			}
-			MainTM.waitTime(200);
-			if (eraseWorld == true) {
-				MsgHandler.debugMsg("The world §e" + eraseWorld + "§b " + MainTM.delWorldDebugMsg); // Console debug msg
+				MsgHandler.debugMsg("The world §e" + w + "§b " + MainTM.delWorldDebugMsg); // Console debug msg
 				MainTM.getInstance().getConfig().getConfigurationSection(MainTM.CF_WORLDSLIST).set(w, null);
 			}
 		}
-		
+
 		MainTM.getInstance().getConfig().getConfigurationSection(MainTM.CF_WORLDSLIST).set(example, null);
-		
-		// #6. Notification
+
+		// #5. Notification
 		MsgHandler.infoMsg(MainTM.worldsCheckMsg); // Final console msg
 	}
 


### PR DESCRIPTION
SleepHandler:
- Don't cancel PlayerBedEnterEvent in non-sleep worlds (Nether/End); the cancel suppressed vanilla bed-explosion.
- Fix integer division in playersSleepingPercentage check (spPercent / 100 was always 0); refactor to spNb * 100 >= rpNb * spPercent.
- Particle debug logs were using errorMsg with mismatched counts; switched to debugMsg with corrected counts.
- "UNKNOW" -> "UNKNOWN" typo.

WorldListHandler:
- Replace fragile List<World>.toString() string-parser with direct World.getName() iteration. Previous parser broke on Paper toString format changes, stripping legitimately-loaded worlds from worldsList.
- Remove MainTM.waitTime(200) inside the strip loop (Thread.sleep on the main thread, multiplied per world).
- Snapshot configured-world keys before iteration to avoid CME.
- Debug message printed the boolean eraseWorld instead of world name.
- Fix #4 -> #6 numbering jump.

LgFileHandler / MainTM:
- Fresh installs leave defaultLang empty in lang.yml. The fallback was LG_DEFAULT ("default"), whose strings are placeholder text asking the admin to "properly define the default language". Players saw this in chat. Add LG_FALLBACK_LANG = "en_US" and pickFallbackLang() helper that prefers en_US when present, falling back to the placeholder only if en_US is missing. Used in checkDefLang() and restoreDefLang().