### PR TITLE
1.12.2: lock-time shortcut, /tm lock/unlock/placeholders/hud/nowitem/animation, refreshing signs, pocket-watch item, ActionBar HUD, %tm_serverday%, enhanced sleep particles + null-clock setTime fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin/
 /.project
 /.gradle/
+target/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 ## Spigot plugin for time management and display
 
 
+### WHAT'S NEW IN 1.12.2
+- **`lock-time:` shortcut** (per world) — `noon`, `dawn`, an `HH:mm`, a raw tick, or `realtime`. Plugin internally rewrites `start`, `daySpeed`, `nightSpeed`, `firstStartTime` for you.
+- **`/tm lock <world> [time]`** / **`/tm unlock <world>`** — toggle a lock at runtime without editing config.
+- **`/tm placeholders`** — list every placeholder the plugin exposes.
+- **`%tm_serverday%`** — server-wide elapsed day counter that survives restarts (uses the existing `initialTickNb`).
+- **Refreshing signs** — place a sign whose first line is `[tm]` (configurable marker) and the next 3 lines may contain `{tm_*}` placeholders; the plugin keeps them up-to-date. Persisted to `signs.yml`.
+- **Pocket-watch /now item** — `/tm nowitem [player]` gives a custom CLOCK item that runs `/now` on right-click.
+- **ActionBar HUD** — opt-in (`hud.actionbar.enabled: false` by default), per-player toggle via `/tm hud on|off`.
+- **Sleep particle enhancements** — END_ROD / GLOW / FIREWORK layers on top of the existing dust transition. Toggle with `sleep.enhanced-particles: false` to keep the original look.
+- **`/tm reload` no longer throws** on frozen worlds — `setTime` / `setFullTime` calls are wrapped so Paper builds that lock the tick rate (datapack dimensions, `/tick freeze`, etc.) silently skip instead of spamming the console.
+
+
 ### TIME MANAGEMENT FUNCTIONALITIES
 Define a start time and a speed modifier per world. Set a suitable refresh rate for the performance of your server.
 

--- a/config-header.txt
+++ b/config-header.txt
@@ -81,3 +81,49 @@ config.yml
 *debugMode*
  Set true to enable colored verbose messages in the console. Useful to understand some mechanisms of this plugin.
 -----
+*lock-time* (per-world, optional)
+ Shortcut for "freeze this world at a specific time" or "follow real time".
+ When set, the plugin internally rewrites start, daySpeed, nightSpeed and
+ firstStartTime for that world. Removing the key (or setting it to 'false')
+ restores admin control of those four values.
+ Accepted values:
+  - noon, midday, dusk, sunset, evening, dawn, sunrise, morning, day, night,
+    midnight                 -> freeze at the matching tick
+  - 0 to 23999                -> freeze at this raw tick
+  - HH:mm or HH:mm:ss         -> freeze at the matching tick
+  - realtime                  -> run at speed 24.0 (1 mc day = 1 real day, UTC)
+  - false / off / none        -> no override (default)
+-----
+*signs* (root section)
+ Refreshing signs. Players place a sign whose first line is the configured
+ 'marker' (default '[tm]'), the next 3 lines may contain plain text + {tm_*}
+ placeholders. The plugin then rewrites the sign's text on the configured
+ refresh interval. Coordinates are persisted to signs.yml across restarts.
+  *enabled* (default true)   - master switch for the feature
+  *refresh-rate* (ticks)     - how often each tracked sign is redrawn
+  *marker*                   - first-line text that turns a sign into a TM sign
+ Permission to create signs: timemanager.signs.create (op by default).
+-----
+*now-item* (root section)
+ Pocket-watch item that triggers the /now action on right-click.
+ Admins give one with /tm nowitem [player].
+  *enabled* (default true)   - master switch
+  *display-name*             - item display name (legacy '&' colors supported)
+  *lore*                     - list of lore lines
+  *cooldown-ticks*           - client cooldown after each right-click
+ Permission to use: timemanager.now-item.use (default true).
+-----
+*hud.actionbar* (root section)
+ Optional per-player ActionBar display of placeholders. Disabled by default.
+  *enabled* (default false)  - global switch
+  *refresh-rate* (ticks)     - how often the action bar is rewritten
+  *format*                   - template with {tm_*} placeholders + legacy colors
+  *worlds*                   - empty list = every world; otherwise a whitelist
+ Players opt out individually with /tm hud off. Per-player state is in-memory
+ and resets at server restart by design.
+-----
+*sleep.enhanced-particles* (boolean, default true)
+ Adds END_ROD, GLOW and FIREWORK particle layers on top of the existing
+ DUST_COLOR_TRANSITION during the sleep / night-skip animation. Set to false
+ to keep the original (subtler) particle look.
+-----

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: TimeManager
-version: 1.12.1
+version: 1.12.2
 api-version: '1.21'
 authors: [ArVdC]
 main: net.vdcraft.arvdc.timemanager.MainTM
@@ -32,6 +32,15 @@ permissions:
             default: true
           timemanager.sleep.counted:
             default: true
+      timemanager.signs.create:
+        description: Create [tm] refreshing signs
+        default: op
+      timemanager.now-item.use:
+        description: Right-click the pocket-watch /now item
+        default: true
+      timemanager.hud.toggle:
+        description: Toggle the personal ActionBar HUD via /tm hud
+        default: true
 commands:
   tm:
     permission: timemanager.admin
@@ -67,6 +76,11 @@ commands:
             /<command> set time [ticks|daypart|HH:mm:ss] [all|world]
             /<command> set update [none|bukkit|curse|spigot|github]
             /<command> set useCmds [true|false]
+            /<command> lock <world> [time|here|realtime]
+            /<command> unlock <world>
+            /<command> placeholders
+            /<command> hud [on|off|toggle]
+            /<command> nowitem [player]
     aliases:
       - tmanag
       - timemanag

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.vdcraft.arvdc</groupId>
 	<artifactId>TimeManager</artifactId>
-	<version>1.12.1</version>
+	<version>1.12.2</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/net/vdcraft/arvdc/timemanager/AdminCmdExecutor.java
+++ b/src/net/vdcraft/arvdc/timemanager/AdminCmdExecutor.java
@@ -14,6 +14,12 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import net.vdcraft.arvdc.timemanager.cmdadmin.TmHelp;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmAnimation;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmHud;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmLock;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmNowItem;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmPlaceholders;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmUnlock;
 import net.vdcraft.arvdc.timemanager.cmdadmin.TmNow;
 import net.vdcraft.arvdc.timemanager.cmdadmin.TmCheckConfig;
 import net.vdcraft.arvdc.timemanager.cmdadmin.TmCheckSql;
@@ -139,6 +145,43 @@ public class AdminCmdExecutor implements CommandExecutor {
 					TmReload.cmdReload(sender, args[1]);
 					return true;
 				}
+			}
+			// List all placeholders the plugin exposes
+			else if (args[0].equalsIgnoreCase(MainTM.CMD_PLACEHOLDERS)) {
+				TmPlaceholders.cmdPlaceholders(sender);
+				return true;
+			}
+			// Toggle the ActionBar HUD for the player
+			else if (args[0].equalsIgnoreCase(MainTM.CMD_HUD)) {
+				String onOff = (nbArgs >= 2) ? args[1] : null;
+				TmHud.cmdHud(sender, onOff);
+				return true;
+			}
+			// Give a "pocket watch" /now item
+			else if (args[0].equalsIgnoreCase(MainTM.CMD_NOWITEM)) {
+				String target = (nbArgs >= 2) ? args[1] : null;
+				TmNowItem.cmdNowItem(sender, target);
+				return true;
+			}
+			// Toggle sleep animation (nightSkipMode) for a world
+			else if (args[0].equalsIgnoreCase(MainTM.CMD_ANIMATION)) {
+				String w = (nbArgs >= 2) ? args[1] : defaultWorld;
+				String onOff = (nbArgs >= 3) ? args[2] : null;
+				TmAnimation.cmdAnimation(sender, w, onOff);
+				return true;
+			}
+			// Lock a world's time at a given tick (or current tick if omitted)
+			else if (args[0].equalsIgnoreCase(MainTM.CMD_LOCK)) {
+				String w = (nbArgs >= 2) ? args[1] : defaultWorld;
+				String timeArg = (nbArgs >= 3) ? args[2] : null;
+				TmLock.cmdLock(sender, w, timeArg);
+				return true;
+			}
+			// Unlock a world (remove its lock-time)
+			else if (args[0].equalsIgnoreCase(MainTM.CMD_UNLOCK)) {
+				String w = (nbArgs >= 2) ? args[1] : defaultWorld;
+				TmUnlock.cmdUnlock(sender, w);
+				return true;
 			}
 			// Synchronize all worlds timers based on server initial time
 			else if (args[0].equalsIgnoreCase(MainTM.CMD_RESYNC)) {

--- a/src/net/vdcraft/arvdc/timemanager/CreateSentenceCommand.java
+++ b/src/net/vdcraft/arvdc/timemanager/CreateSentenceCommand.java
@@ -27,8 +27,8 @@ public class CreateSentenceCommand implements TabCompleter {
 
 	// List of admin sub-commands
 	List<String> tmCmdArgsList() {
-		if (MainTM.serverMcVersion >= MainTM.reqMcVForUpdate) return Arrays.asList(MainTM.CMD_CHECKCONFIG, MainTM.CMD_CHECKSQL, MainTM.CMD_CHECKTIME, MainTM.CMD_CHECKUPDATE, MainTM.CMD_HELP, MainTM.CMD_TMNOW, MainTM.CMD_RELOAD, MainTM.CMD_RESYNC, MainTM.CMD_SET);
-		else return Arrays.asList(MainTM.CMD_CHECKCONFIG, MainTM.CMD_CHECKSQL, MainTM.CMD_CHECKTIME, MainTM.CMD_HELP, MainTM.CMD_TMNOW, MainTM.CMD_RELOAD, MainTM.CMD_RESYNC, MainTM.CMD_SET);
+		if (MainTM.serverMcVersion >= MainTM.reqMcVForUpdate) return Arrays.asList(MainTM.CMD_CHECKCONFIG, MainTM.CMD_CHECKSQL, MainTM.CMD_CHECKTIME, MainTM.CMD_CHECKUPDATE, MainTM.CMD_HELP, MainTM.CMD_TMNOW, MainTM.CMD_RELOAD, MainTM.CMD_RESYNC, MainTM.CMD_SET, MainTM.CMD_LOCK, MainTM.CMD_UNLOCK, MainTM.CMD_PLACEHOLDERS, MainTM.CMD_HUD, MainTM.CMD_NOWITEM, MainTM.CMD_ANIMATION);
+		else return Arrays.asList(MainTM.CMD_CHECKCONFIG, MainTM.CMD_CHECKSQL, MainTM.CMD_CHECKTIME, MainTM.CMD_HELP, MainTM.CMD_TMNOW, MainTM.CMD_RELOAD, MainTM.CMD_RESYNC, MainTM.CMD_SET, MainTM.CMD_LOCK, MainTM.CMD_UNLOCK, MainTM.CMD_PLACEHOLDERS, MainTM.CMD_HUD, MainTM.CMD_NOWITEM, MainTM.CMD_ANIMATION);
 	}
 	// List of admin sub-commands having a 'help'
 	List<String> tmHelpArgsList() {

--- a/src/net/vdcraft/arvdc/timemanager/MainTM.java
+++ b/src/net/vdcraft/arvdc/timemanager/MainTM.java
@@ -33,6 +33,8 @@ import net.vdcraft.arvdc.timemanager.mainclass.SignsHandler;
 import net.vdcraft.arvdc.timemanager.mainclass.SqlHandler;
 import net.vdcraft.arvdc.timemanager.mainclass.UpdateHandler;
 import net.vdcraft.arvdc.timemanager.mainclass.WorldListHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.NowItemHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.RefreshingSignHandler;
 import net.vdcraft.arvdc.timemanager.mainclass.SleepHandler;
 import net.vdcraft.arvdc.timemanager.mainclass.SyncHandler;
 import net.vdcraft.arvdc.timemanager.placeholders.ChatHandler;
@@ -96,7 +98,7 @@ public class MainTM extends JavaPlugin {
 	public static String defSleep = "true";
 	public static String defSync = "false";
 	public static String defFirstStartTime = "default";
-	public static String defNightSkipMode = "default";
+	public static String defNightSkipMode = "animation";
 	public static String defNightSkipNbPlayers = "100%";
 	protected static String defUpdateMsgSrc = "none";
 	protected static int defTitleFadeIn = 20;
@@ -143,6 +145,23 @@ public class MainTM extends JavaPlugin {
 
 	// Initialize server tick
 	protected static Long initialTick;
+
+	/** Public read-only accessor for the server's reference tick. Useful for
+	 *  external integrations (PAPI expansion, dashboard plugins) that should
+	 *  not have direct write access. */
+	public static Long getInitialTick() {
+		return initialTick;
+	}
+
+	/** Server's "first ever" reference tick — persisted ONCE on the very
+	 *  first plugin enable, never overwritten. Used by {@code %tm_serverday%}
+	 *  to count days from the moment TimeManager was first installed,
+	 *  independently of the resetOnStartup behaviour for {@link #initialTick}. */
+	public static Long getFirstEverTick() {
+		Long v = MainTM.getInstance().getConfig().getLong(CF_INITIALTICK + "." + CF_FIRSTEVERTICK, -1L);
+		if (v == null || v < 0) return initialTick;
+		return v;
+	}
 	protected static String initialTime;
 
 	// Config file keys
@@ -158,11 +177,13 @@ public class MainTM extends JavaPlugin {
 	public static final String CF_SLEEP = "sleep";
 	public static final String CF_SYNC = "sync";
 	public static final String CF_FIRSTSTARTTIME = "firstStartTime";
+	public static final String CF_LOCKTIME = "lock-time";
 	public static final String CF_NIGHTSKIP_MODE = "nightSkipMode";
 	public static final String CF_NIGHTSKIP_REQUIREDPLAYERS = "nightSkipRequiredPlayers";
 	public static final String CF_NIGHTSKIP_LEGACYPERCENTAGE = "nightSkipLegacyPercentage";
 	protected static final String CF_INITIALTICK = "initialTick";
 	protected static final String CF_INITIALTICKNB = "initialTickNb";
+	protected static final String CF_FIRSTEVERTICK = "firstEverTickNb";
 	protected static final String CF_RESETONSTARTUP = "resetOnStartup";
 	protected static final String CF_USEMYSQL = "useMySql";
 	protected static final String CF_MYSQL = "mySql";
@@ -252,6 +273,12 @@ public class MainTM extends JavaPlugin {
 	protected static final String CMD_RESYNC = "resync";
 	protected static final String CMD_SET = "set";
 	protected static final String CMD_TMNOW = "now";
+	protected static final String CMD_LOCK = "lock";
+	protected static final String CMD_UNLOCK = "unlock";
+	protected static final String CMD_PLACEHOLDERS = "placeholders";
+	protected static final String CMD_HUD = "hud";
+	protected static final String CMD_NOWITEM = "nowitem";
+	protected static final String CMD_ANIMATION = "animation";
 
 	// "/tm set" sub-commands names
 	protected static final String CMD_SET_DATE = "date";
@@ -344,7 +371,8 @@ public class MainTM extends JavaPlugin {
 	public static final String PH_MM = "mm";
 	public static final String PH_YY = "yy";
 	public static final String PH_YYYY = "yyyy";
-	
+	public static final String PH_SERVERDAY = "serverday";
+
 	// Permissions names
 	protected static final String PERM_TM = "timemanager.admin";
 	protected static final String PERM_NOW = "timemanager.now.cmd";
@@ -759,7 +787,15 @@ public class MainTM extends JavaPlugin {
 			getServer().getPluginManager().registerEvents(new ConsoleCommandHandler(), this);	
 			
 			// #13. Listen to worlds events
-			getServer().getPluginManager().registerEvents(new WorldListHandler(), this);	 // TODO		
+			getServer().getPluginManager().registerEvents(new WorldListHandler(), this);	 // TODO
+
+			// #13.A. Refreshing signs ([tm] marker) — listener + scheduler
+			getServer().getPluginManager().registerEvents(new RefreshingSignHandler(), this);
+			RefreshingSignHandler.init();
+
+			// #13.B. Pocket-watch /now item — listener + config defaults
+			NowItemHandler.ensureDefaults();
+			getServer().getPluginManager().registerEvents(new NowItemHandler(), this);
 
 			// #14. Synchronize worlds and create scheduled task for faking the time increase/decrease
 			SyncHandler.firstSync();

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmAnimation.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmAnimation.java
@@ -1,0 +1,70 @@
+package net.vdcraft.arvdc.timemanager.cmdadmin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+
+/**
+ * /tm animation &lt;world&gt; [on|off|toggle]
+ *
+ * Shortcut for flipping {@code worldsList.<world>.nightSkipMode} between
+ * {@code animation} and {@code default}. When {@code animation} is on, the
+ * sleep particle show (DUST_COLOR_TRANSITION + the enhanced END_ROD / GLOW /
+ * FIREWORK layers) plays during the night-skip sequence; otherwise the
+ * vanilla instant skip is used.
+ *
+ * No argument or {@code toggle} flips the current value. {@code on} forces
+ * animation; {@code off} forces default.
+ */
+public class TmAnimation extends MainTM {
+
+	public static void cmdAnimation(CommandSender sender, String world, String onOffArg) {
+		// #1. Validate
+		if (Bukkit.getWorld(world) == null) {
+			sender.sendMessage(ChatColor.RED + "Unknown world: " + ChatColor.YELLOW + world);
+			return;
+		}
+		if (!MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(world)) {
+			sender.sendMessage(ChatColor.RED + "World " + ChatColor.YELLOW + world
+					+ ChatColor.RED + " isn't tracked by TimeManager.");
+			return;
+		}
+
+		String key = CF_WORLDSLIST + "." + world + "." + CF_NIGHTSKIP_MODE;
+		String current = MainTM.getInstance().getConfig().getString(key, ARG_DEFAULT);
+		boolean isOn = current.equalsIgnoreCase(ARG_ANIMATION);
+
+		boolean enable;
+		if (onOffArg == null || onOffArg.isEmpty() || onOffArg.equalsIgnoreCase("toggle")) {
+			enable = !isOn;
+		} else if (onOffArg.equalsIgnoreCase("on") || onOffArg.equalsIgnoreCase("true")
+				|| onOffArg.equalsIgnoreCase(ARG_ANIMATION)) {
+			enable = true;
+		} else if (onOffArg.equalsIgnoreCase("off") || onOffArg.equalsIgnoreCase("false")
+				|| onOffArg.equalsIgnoreCase(ARG_DEFAULT)) {
+			enable = false;
+		} else if (onOffArg.equalsIgnoreCase(ARG_INSTANT)) {
+			// Pass through explicit 'instant' option from the original
+			// nightSkipMode enum.
+			MainTM.getInstance().getConfig().set(key, ARG_INSTANT);
+			MainTM.getInstance().saveConfig();
+			sender.sendMessage(ChatColor.GOLD + "nightSkipMode for " + ChatColor.YELLOW + world
+					+ ChatColor.GOLD + " is now " + ChatColor.YELLOW + ARG_INSTANT);
+			return;
+		} else {
+			sender.sendMessage(ChatColor.RED + "Usage: /tm animation <world> [on|off|toggle|instant]");
+			return;
+		}
+
+		String newValue = enable ? ARG_ANIMATION : ARG_DEFAULT;
+		MainTM.getInstance().getConfig().set(key, newValue);
+		MainTM.getInstance().saveConfig();
+
+		sender.sendMessage(ChatColor.GOLD + "Sleep animation on " + ChatColor.YELLOW + world
+				+ ChatColor.GOLD + " is now "
+				+ (enable ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF")
+				+ ChatColor.GRAY + " (nightSkipMode = " + newValue + ").");
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmHelp.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmHelp.java
@@ -12,63 +12,76 @@ public class TmHelp extends MainTM {
 	 * Help messages
 	 */
 	// Always copy this content in the README.md
-	private static String headerHelp = ChatColor.YELLOW + "---------" + ChatColor.RESET + " Help: " + prefixTMColor + ChatColor.YELLOW + " ---------";
+	private static String headerHelp = ChatColor.YELLOW + "---------" + ChatColor.GRAY + " Help: " + prefixTMColor + ChatColor.YELLOW + " ---------";
 	private static String checkconfigHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_CHECKCONFIG
-			+ " " + ChatColor.RESET + "Admins and console can display a summary of the config.yml and lang.yml files.";
+			+ " " + ChatColor.GRAY + "Admins and console can display a summary of the config.yml and lang.yml files.";
 	private static String checkSqlHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_CHECKSQL
-			+ " " + ChatColor.RESET + "Check the availability of the mySQL server according to the values provided in the config.yml file. This only checks the ip address and the correct port opening.";
+			+ " " + ChatColor.GRAY + "Check the availability of the mySQL server according to the values provided in the config.yml file. This only checks the ip address and the correct port opening.";
 	private static String checktimeHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_CHECKTIME
-			+ " [all|server|world] " + ChatColor.RESET + "Admins and console can display a debug/managing message, who displays the startup server's time, the current server's time and the current time, start time and speed for a specific world (or for all of them).";
+			+ " [all|server|world] " + ChatColor.GRAY + "Admins and console can display a debug/managing message, who displays the startup server's time, the current server's time and the current time, start time and speed for a specific world (or for all of them).";
 	private static String checkupdateHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_CHECKUPDATE
-			+ " [bukkit|spigot|github] " + ChatColor.RESET + "Search if a newer version of the plugin exists on the chosen server. (MC 1.18.9+ only)";
+			+ " [bukkit|spigot|github] " + ChatColor.GRAY + "Search if a newer version of the plugin exists on the chosen server. (MC 1.18.9+ only)";
 	private static String helpHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_HELP
-			+ " [cmd] [<subCmd>] " + ChatColor.RESET + "Help provides you the correct usage and a short description of targeted command or subcommand.";
+			+ " [cmd] [<subCmd>] " + ChatColor.GRAY + "Help provides you the correct usage and a short description of targeted command or subcommand.";
 	private static String tmNowHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_NOW
-			+ " [msg|title|actionbar] [all|player|world] " + ChatColor.RESET + "Send the '/now' (chat, title or action bar) message to a specific player, all players in a specific world, or all online players.";
+			+ " [msg|title|actionbar] [all|player|world] " + ChatColor.GRAY + "Send the '/now' (chat, title or action bar) message to a specific player, all players in a specific world, or all online players.";
 	private static String reloadHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_RELOAD
-			+ " [all|cmds|config|lang] " + ChatColor.RESET + "This command allows you to reload datas from yaml files after manual modifications. All timers will be immediately resynchronized.";
+			+ " [all|cmds|config|lang] " + ChatColor.GRAY + "This command allows you to reload datas from yaml files after manual modifications. All timers will be immediately resynchronized.";
 	private static String resyncHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_RESYNC
-			+ " [all|world] " + ChatColor.RESET + "This command will re-synchronize a single or all worlds timers, based on the startup server's time, the elapsed time and the current speed modifier.";
+			+ " [all|world] " + ChatColor.GRAY + "This command will re-synchronize a single or all worlds timers, based on the startup server's time, the elapsed time and the current speed modifier.";
 	private static String setDateHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_DATE
-			+ " [today|yyyy-mm-dd] [all|world] " + ChatColor.RESET + "Sets current date for the specified world (or all of them). Could be 'today' or any yyyy-mm-dd date. The length of the months corresponds to reality, with the exception of February which always lasts 28 days. A year therefore always lasts 365 days.";
+			+ " [today|yyyy-mm-dd] [all|world] " + ChatColor.GRAY + "Sets current date for the specified world (or all of them). Could be 'today' or any yyyy-mm-dd date. The length of the months corresponds to reality, with the exception of February which always lasts 28 days. A year therefore always lasts 365 days.";
 	private static String setDebugHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_DEBUG
-			+ " [true|false] " + ChatColor.RESET + "Set true to enable colored verbose messages in the console. Useful to understand some mechanisms of this plugin.";
+			+ " [true|false] " + ChatColor.GRAY + "Set true to enable colored verbose messages in the console. Useful to understand some mechanisms of this plugin.";
 	private static String setDefLangHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_DEFLANG
-			+ " [lg_LG] " + ChatColor.RESET + "Choose the translation to use if player's locale doesn't exist in the lang.yml or when 'multiLang' is 'false'.";
+			+ " [lg_LG] " + ChatColor.GRAY + "Choose the translation to use if player's locale doesn't exist in the lang.yml or when 'multiLang' is 'false'.";
 	private static String setDurationHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_DURATION
-			+ " [00d-00h-00m-00s] [all|world] " + ChatColor.RESET + "Sets the speed of the world based on the desired duration rather than with a speed multiplier.";
-	private static String setDuration_D_N_HelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_D_DURATION + " " + ChatColor.RESET + "or " + ChatColor.GOLD + CMD_SET_N_DURATION
-			+ " [00d-00h-00m-00s] [all|world] " + ChatColor.RESET + "The length of day and night can be defined separately.";
+			+ " [00d-00h-00m-00s] [all|world] " + ChatColor.GRAY + "Sets the speed of the world based on the desired duration rather than with a speed multiplier.";
+	private static String setDuration_D_N_HelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_D_DURATION + " " + ChatColor.GRAY + "or " + ChatColor.GOLD + CMD_SET_N_DURATION
+			+ " [00d-00h-00m-00s] [all|world] " + ChatColor.GRAY + "The length of day and night can be defined separately.";
 	private static String setE_DaysHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_E_DAYS
-			+ " [0 → ∞] [all|world] " + ChatColor.RESET + "Sets current number of elapsed days for the specified world (or all of them). Could be an integer between '0' and infinity (or almost). Setting this to '0' will bring the world back to day one.";
+			+ " [0 → ∞] [all|world] " + ChatColor.GRAY + "Sets current number of elapsed days for the specified world (or all of them). Could be an integer between '0' and infinity (or almost). Setting this to '0' will bring the world back to day one.";
 	private static String setFirstStartTimeHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_FIRSTSTARTTIME
-			+ " [default|previous|start] [all|world] " + ChatColor.RESET + "Forces the time at which a world starts when starting the server. The value 'default' allows the usual resynchronization at startup. The value 'start' forces the world to start at the time specified in the world's 'start' node. The value 'previous' returns the time in the world before the server was shut down.";
+			+ " [default|previous|start] [all|world] " + ChatColor.GRAY + "Forces the time at which a world starts when starting the server. The value 'default' allows the usual resynchronization at startup. The value 'start' forces the world to start at the time specified in the world's 'start' node. The value 'previous' returns the time in the world before the server was shut down.";
 	private static String setInitialTickHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_INITIALTICK
-			+ " [ticks|HH:mm:ss] " + ChatColor.RESET + "Modify the server's initial tick.";
+			+ " [ticks|HH:mm:ss] " + ChatColor.GRAY + "Modify the server's initial tick.";
 	private static String setMultilangHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_MULTILANG
-			+ " [true|false] " + ChatColor.RESET + "Set true or false to use an automatic translation for the " + ChatColor.ITALIC + "/now" + ChatColor.RESET + " command.";
+			+ " [true|false] " + ChatColor.GRAY + "Set true or false to use an automatic translation for the " + ChatColor.ITALIC + "/now" + ChatColor.GRAY + " command.";
 	private static String setPlayerOffsetHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_PLAYEROFFSET
-			+ " [-23999 → 23999] [all|player] " + ChatColor.RESET + "Define a specific offset relative to the world time on player's client (the world speed will be still active). Set to '0' to cancel.";
+			+ " [-23999 → 23999] [all|player] " + ChatColor.GRAY + "Define a specific offset relative to the world time on player's client (the world speed will be still active). Set to '0' to cancel.";
 	private static String setPlayerTimeHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_PLAYERTIME
-			+ " [ticks|daypart|HH:mm:ss|reset] [all|player] " + ChatColor.RESET + "Define a specific time on player's client (the world speed will be still active). Use the 'reset' argument to cancel.";
+			+ " [ticks|daypart|HH:mm:ss|reset] [all|player] " + ChatColor.GRAY + "Define a specific time on player's client (the world speed will be still active). Use the 'reset' argument to cancel.";
 	private static String setRefreshRateHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_REFRESHRATE
-			+ " [ticks] " + ChatColor.RESET + "Set the delay (in ticks) before actualizing the speed stretch/expand effect. Must be an integer between '" + refreshMin + "' and '" + refreshMax + "'. Default value is '" + defRefresh + " ticks', please note that a too small value can cause server lags.";
+			+ " [ticks] " + ChatColor.GRAY + "Set the delay (in ticks) before actualizing the speed stretch/expand effect. Must be an integer between '" + refreshMin + "' and '" + refreshMax + "'. Default value is '" + defRefresh + " ticks', please note that a too small value can cause server lags.";
 	private static String setSleepHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_SLEEP
-			+ " [true|false|linked] [all|world] " + ChatColor.RESET + "Define if players can sleep until the next day in the specified world (or in all of them). By default, all worlds will start with parameter true, unless their timer is in real time who will be necessary false. If you want to both allow sleep and keep the same time in multiple worlds, you can use the 'linked' function which allows a group of worlds to spend the night together.";
+			+ " [true|false|linked] [all|world] " + ChatColor.GRAY + "Define if players can sleep until the next day in the specified world (or in all of them). By default, all worlds will start with parameter true, unless their timer is in real time who will be necessary false. If you want to both allow sleep and keep the same time in multiple worlds, you can use the 'linked' function which allows a group of worlds to spend the night together.";
 	private static String setSpeedHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_SPEED
-			+ " [0.0 → 20.0] [all|world] " + ChatColor.RESET + "The decimal number argument will multiply the world(s) speed. Use 0.0 to freeze time, numbers from 0.01 to 0.99 to slow time, 1.0 to get normal speed and numbers from 1.1 to " + speedMax + " to speedup time. Set this value to 24.0 or 'realtime' to make the world time match the real speed time.";
-	private static String setSpeed_D_N_HelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_D_SPEED + " " + ChatColor.RESET + "or " + ChatColor.GOLD + CMD_SET_N_SPEED
-			+ " [0.0 → 20.0] [all|world] " + ChatColor.RESET + "Night and day speeds can be different from each other.";
+			+ " [0.0 → 20.0] [all|world] " + ChatColor.GRAY + "The decimal number argument will multiply the world(s) speed. Use 0.0 to freeze time, numbers from 0.01 to 0.99 to slow time, 1.0 to get normal speed and numbers from 1.1 to " + speedMax + " to speedup time. Set this value to 24.0 or 'realtime' to make the world time match the real speed time.";
+	private static String setSpeed_D_N_HelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_D_SPEED + " " + ChatColor.GRAY + "or " + ChatColor.GOLD + CMD_SET_N_SPEED
+			+ " [0.0 → 20.0] [all|world] " + ChatColor.GRAY + "Night and day speeds can be different from each other.";
 	private static String setStartHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_START
-			+ " [ticks|daypart|HH:mm:ss|timeShift] [all|world] " + ChatColor.RESET + "Defines the time at server startup for the specified world (or all of them). By default, all worlds will start at tick #0. The timer(s) will be immediately resynchronized. If a world is using the real time speed, the start value will determine the UTC time shift and values like +1 or -1 will be accepted.";
+			+ " [ticks|daypart|HH:mm:ss|timeShift] [all|world] " + ChatColor.GRAY + "Defines the time at server startup for the specified world (or all of them). By default, all worlds will start at tick #0. The timer(s) will be immediately resynchronized. If a world is using the real time speed, the start value will determine the UTC time shift and values like +1 or -1 will be accepted.";
 	private static String setSyncHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_SYNC
-			+ " [true|false] [all|world] " + ChatColor.RESET + "Define if the speed distortion method will increase/decrease the world's actual tick, or fit the theoretical tick value based on the server one. By default, all worlds will start with parameter false. Real time based worlds and frozen worlds do not use this option, on the other hand this will affect even the worlds with a normal speed.";
+			+ " [true|false] [all|world] " + ChatColor.GRAY + "Define if the speed distortion method will increase/decrease the world's actual tick, or fit the theoretical tick value based on the server one. By default, all worlds will start with parameter false. Real time based worlds and frozen worlds do not use this option, on the other hand this will affect even the worlds with a normal speed.";
 	private static String setTimeHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_TIME
-			+ " [ticks|daypart|HH:mm:ss] [all|world] " + ChatColor.RESET + "Sets current time for the specified world (or all of them). Consider using this instead of the vanilla " + ChatColor.ITALIC + "/time" + ChatColor.RESET + " command. The tab completion also provides handy presets like \"day\", \"noon\", \"night\", \"midnight\", etc.";
+			+ " [ticks|daypart|HH:mm:ss] [all|world] " + ChatColor.GRAY + "Sets current time for the specified world (or all of them). Consider using this instead of the vanilla " + ChatColor.ITALIC + "/time" + ChatColor.GRAY + " command. The tab completion also provides handy presets like \"day\", \"noon\", \"night\", \"midnight\", etc.";
 	private static String setupdateSrcHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_UPDATE
-			+ " [bukkit|spigot|github] " + ChatColor.RESET + "Define the source server for the update search. (MC 1.8.8+ only)";
+			+ " [bukkit|spigot|github] " + ChatColor.GRAY + "Define the source server for the update search. (MC 1.8.8+ only)";
 	private static String setUseCmdsHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " " + CMD_SET_USECMDS
-			+ " [true|false] " + ChatColor.RESET + "Set true to enable a custom commands scheduler. See the " + CMDSFILENAME + " file for details.";
+			+ " [true|false] " + ChatColor.GRAY + "Set true to enable a custom commands scheduler. See the " + CMDSFILENAME + " file for details.";
+	// ── 1.12.2 additions ──
+	private static String lockHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_LOCK
+			+ " <world> [time|here|realtime] " + ChatColor.GRAY + "Freezes a world at the given time (noon, dawn, dusk, midnight, day, night, raw tick, HH:mm, 'here' for the world's current tick, or 'realtime' for UTC sync).";
+	private static String unlockHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_UNLOCK
+			+ " <world> " + ChatColor.GRAY + "Removes the lock-time on the world. Admin must restore daySpeed/nightSpeed manually if normal time flow is desired.";
+	private static String placeholdersHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_PLACEHOLDERS
+			+ " " + ChatColor.GRAY + "Lists every placeholder the plugin exposes (PAPI form %tm_X% and in-message {tm_X} form).";
+	private static String hudHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_HUD
+			+ " [on|off|toggle] " + ChatColor.GRAY + "Toggle the per-player ActionBar HUD. Requires hud.actionbar.enabled: true in config for the broadcaster to run globally.";
+	private static String nowItemHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_NOWITEM
+			+ " [player] " + ChatColor.GRAY + "Gives a custom CLOCK 'Pocket Watch' item that runs the /now action on right-click.";
+	private static String animationHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_ANIMATION
+			+ " <world> [on|off|toggle] " + ChatColor.GRAY + "Shortcut for nightSkipMode = animation/default on a world. Controls the sleep particle show.";
 	// Except this line, used when 'set' is used without additional argument
 	private static String missingSetArgHelpMsg = ChatColor.GOLD + "/" + CMD_TM + " " + CMD_SET + " ["
 			+ CMD_SET_DATE + "|"
@@ -93,7 +106,7 @@ public class TmHelp extends MainTM {
 			+ CMD_SET_TIME + "|"
 			+ CMD_SET_UPDATE + "|"
 			+ CMD_SET_USECMDS
-			+ "]: " + ChatColor.RESET + "This command, used with arguments, permit to change plugin parameters.";
+			+ "]: " + ChatColor.GRAY + "This command, used with arguments, permit to change plugin parameters.";
 
 	/**
 	 * CMD /tm help [cmd]
@@ -203,6 +216,25 @@ public class TmHelp extends MainTM {
 			case CMD_SET : // // /tm help set <null>
 				specificCmdMsg = missingSetArgHelpMsg; // Help msg (in case of 1 arg)
 				break;
+			// ── 1.12.2 additions ──
+			case CMD_LOCK :
+				specificCmdMsg = lockHelpMsg;
+				break;
+			case CMD_UNLOCK :
+				specificCmdMsg = unlockHelpMsg;
+				break;
+			case CMD_PLACEHOLDERS :
+				specificCmdMsg = placeholdersHelpMsg;
+				break;
+			case CMD_HUD :
+				specificCmdMsg = hudHelpMsg;
+				break;
+			case CMD_NOWITEM :
+				specificCmdMsg = nowItemHelpMsg;
+				break;
+			case CMD_ANIMATION :
+				specificCmdMsg = animationHelpMsg;
+				break;
 			// Maybe someone could forget the 'set' part, so think of its place
 			case CMD_SET_DATE :
 			case CMD_SET_DEBUG :
@@ -238,8 +270,32 @@ public class TmHelp extends MainTM {
 		}
 		// Else, display basic help msg and the list of cmds from plugin.yml
 		else {
-			sender.sendMessage(helpHelpMsg); // Final msg (always)
-			return false;
+			// Display a colored, structured list of every subcommand instead
+			// of falling back to plugin.yml's plain-text usage block.
+			sender.sendMessage(helpHelpMsg);
+			sender.sendMessage(ChatColor.GRAY + " ");
+			sender.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "Inspection");
+			sender.sendMessage(checkconfigHelpMsg);
+			sender.sendMessage(checkSqlHelpMsg);
+			sender.sendMessage(checktimeHelpMsg);
+			if (MainTM.serverMcVersion >= MainTM.reqMcVForUpdate) sender.sendMessage(checkupdateHelpMsg);
+			sender.sendMessage(placeholdersHelpMsg);
+			sender.sendMessage(ChatColor.GRAY + " ");
+			sender.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "Run-time control");
+			sender.sendMessage(tmNowHelpMsg);
+			sender.sendMessage(reloadHelpMsg);
+			sender.sendMessage(resyncHelpMsg);
+			sender.sendMessage(lockHelpMsg);
+			sender.sendMessage(unlockHelpMsg);
+			sender.sendMessage(animationHelpMsg);
+			sender.sendMessage(hudHelpMsg);
+			sender.sendMessage(nowItemHelpMsg);
+			sender.sendMessage(ChatColor.GRAY + " ");
+			sender.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "Configuration (/tm set ...)");
+			sender.sendMessage(missingSetArgHelpMsg);
+			sender.sendMessage(ChatColor.GRAY + "Type " + ChatColor.GOLD + "/" + CMD_TM + " " + CMD_HELP
+					+ " <cmd>" + ChatColor.GRAY + " for details on a specific command.");
+			return true;
 		}
 	}
 

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmHud.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmHud.java
@@ -1,0 +1,47 @@
+package net.vdcraft.arvdc.timemanager.cmdadmin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.mainclass.ActionBarHandler;
+
+/**
+ * /tm hud [on|off]
+ *
+ * Per-player toggle for the optional ActionBar HUD. Players use this to opt
+ * out (e.g. they prefer to keep the action bar clear for other plugins).
+ * Default opt-out state matches {@code hud.actionbar.enabled} in config —
+ * if the HUD is globally off no one sees it regardless.
+ *
+ * Opt-out is kept in memory only and resets on restart, by design — opt-out
+ * is a quality-of-life toggle, not a persistent setting worth a data file.
+ */
+public class TmHud extends MainTM {
+
+	public static void cmdHud(CommandSender sender, String onOffArg) {
+		if (!(sender instanceof Player)) {
+			sender.sendMessage(ChatColor.RED + "/tm hud is player-only.");
+			return;
+		}
+		Player p = (Player) sender;
+
+		boolean off;
+		if (onOffArg == null || onOffArg.isEmpty() || onOffArg.equalsIgnoreCase("toggle")) {
+			off = !ActionBarHandler.isOptedOut(p.getUniqueId());
+		} else if (onOffArg.equalsIgnoreCase("on") || onOffArg.equalsIgnoreCase("true")) {
+			off = false;
+		} else if (onOffArg.equalsIgnoreCase("off") || onOffArg.equalsIgnoreCase("false")) {
+			off = true;
+		} else {
+			p.sendMessage(ChatColor.RED + "Usage: /tm hud [on|off|toggle]");
+			return;
+		}
+
+		ActionBarHandler.setOptOut(p.getUniqueId(), off);
+		p.sendMessage(ChatColor.GOLD + "ActionBar HUD is now "
+				+ (off ? ChatColor.RED + "OFF" : ChatColor.GREEN + "ON")
+				+ ChatColor.GOLD + " for you.");
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmLock.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmLock.java
@@ -1,0 +1,66 @@
+package net.vdcraft.arvdc.timemanager.cmdadmin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.mainclass.LockTimeHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.MsgHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.SpeedHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.SyncHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.ValuesConverter;
+
+/**
+ * /tm lock &lt;world&gt; [time]
+ *
+ * Freezes a world at the specified time, or at the world's current time if no
+ * time argument is provided. Writes {@code lock-time} into the world's config
+ * section and applies the derived speed/start values immediately. The world's
+ * scheduler is restarted so the change takes effect without a full plugin
+ * reload.
+ *
+ * Time argument accepts the same values as {@code lock-time:} in the config:
+ * named presets (noon, dawn, dusk, midnight, day, night),
+ * raw ticks (0–23999), HH:mm format, or {@code realtime}.
+ */
+public class TmLock extends MainTM {
+
+	public static void cmdLock(CommandSender sender, String world, String timeArg) {
+
+		// #1. Validate world exists and is in the plugin's world list
+		if (Bukkit.getWorld(world) == null) {
+			MsgHandler.cmdErrorMsg(sender, "§cUnknown world: §e" + world + "§c.", CMD_LOCK);
+			return;
+		}
+		if (!MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(world)) {
+			MsgHandler.cmdErrorMsg(sender, "§cUnknown world: §e" + world + "§c.", CMD_LOCK);
+			return;
+		}
+
+		// #2. Resolve the time argument. Empty / null → use the world's current tick.
+		String resolvedValue;
+		if (timeArg == null || timeArg.isEmpty() || timeArg.equalsIgnoreCase("here") || timeArg.equalsIgnoreCase("now")) {
+			long currentTick = Bukkit.getWorld(world).getTime();
+			resolvedValue = String.valueOf(currentTick);
+		} else {
+			resolvedValue = timeArg;
+		}
+
+		// #3. Write lock-time + apply the derived values
+		LockTimeHandler.setLockTime(world, resolvedValue);
+
+		// #4. Re-validate / clamp the derived values like the config loader does
+		ValuesConverter.restrainStart(world);
+		ValuesConverter.restrainSpeed(world);
+		ValuesConverter.restrainFirstStartTime(world);
+
+		// #5. Persist + apply
+		MainTM.getInstance().saveConfig();
+		SyncHandler.worldSync(sender, world, ARG_START);
+		SpeedHandler.speedScheduler(world);
+
+		// #6. Notify
+		MsgHandler.infoMsg("The world §e" + world + "§r is now locked (lock-time: §e" + resolvedValue + "§r).");
+		MsgHandler.playerAdminMsg(sender, "Locked §e" + world + "§r at §e" + resolvedValue + "§r.");
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmNowItem.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmNowItem.java
@@ -1,0 +1,37 @@
+package net.vdcraft.arvdc.timemanager.cmdadmin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.mainclass.NowItemHandler;
+
+/**
+ * /tm nowitem [player]
+ *
+ * Gives a pocket-watch (custom {@link org.bukkit.Material#CLOCK}) to the
+ * target player. The item is recognised by {@link NowItemHandler} on
+ * right-click and runs the {@code /now} action.
+ */
+public class TmNowItem extends MainTM {
+
+	public static void cmdNowItem(CommandSender sender, String targetName) {
+		Player target = null;
+		if (targetName == null || targetName.isEmpty()) {
+			if (sender instanceof Player) target = (Player) sender;
+		} else {
+			target = Bukkit.getPlayerExact(targetName);
+		}
+		if (target == null) {
+			sender.sendMessage(ChatColor.RED + "Target player not found or offline.");
+			return;
+		}
+		target.getInventory().addItem(NowItemHandler.createItem());
+		sender.sendMessage(ChatColor.GOLD + "Gave a Pocket Watch to " + ChatColor.YELLOW + target.getName() + ChatColor.GOLD + ".");
+		if (sender != target) {
+			target.sendMessage(ChatColor.GOLD + "You received a " + ChatColor.YELLOW + "Pocket Watch" + ChatColor.GOLD + ".");
+		}
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmPlaceholders.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmPlaceholders.java
@@ -1,0 +1,68 @@
+package net.vdcraft.arvdc.timemanager.cmdadmin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+
+/**
+ * /tm placeholders
+ *
+ * Lists every placeholder the plugin exposes — both the legacy {curly-brace}
+ * form used inside in-game messages (TmNow, signs, etc.) and the PlaceholderAPI
+ * form {@code %tm_<name>%} for other plugins (TAB, scoreboards, holograms).
+ *
+ * Permission: {@link MainTM#PERM_PLACEHOLDERS} (granted to ops by default).
+ */
+public class TmPlaceholders extends MainTM {
+
+	private static final String[][] ROWS = new String[][] {
+		// {placeholder, description}
+		{ PH_PLAYER,     "Player name" },
+		{ PH_WORLD,      "Player's current world" },
+		{ PH_TICK,       "Current world tick (0–23999)" },
+		{ PH_TIME12,     "Time in 12h format (e.g. 02:30 PM)" },
+		{ PH_TIME24,     "Time in 24h format (e.g. 14:30)" },
+		{ PH_HOURS12,    "Hours in 12h format" },
+		{ PH_HOURS24,    "Hours in 24h format" },
+		{ PH_MINUTES,    "Minutes" },
+		{ PH_SECONDS,    "Seconds" },
+		{ PH_AMPM,       "AM / PM" },
+		{ PH_DAYPART,    "Day phase (dawn, day, dusk, night, midnight)" },
+		{ PH_C_DAY,      "Current world day number" },
+		{ PH_E_DAYS,     "Total elapsed days in the world" },
+		{ PH_DAYNAME,    "Day of week (Monday, Tuesday, ...)" },
+		{ PH_YEARDAY,    "Day of year (1–365)" },
+		{ PH_YEARWEEK,   "Week of year (1–52)" },
+		{ PH_WEEK,       "Week number" },
+		{ PH_MONTHNAME,  "Month name (January, February, ...)" },
+		{ PH_DD,         "Day of month (01–31)" },
+		{ PH_MM,         "Month (01–12)" },
+		{ PH_YY,         "Year, 2-digit" },
+		{ PH_YYYY,       "Year, 4-digit" },
+		{ PH_SERVERDAY,  "Server-wide elapsed days (persists across restarts)" },
+	};
+
+	public static void cmdPlaceholders(CommandSender sender) {
+		if (sender instanceof org.bukkit.entity.Player
+				&& !sender.hasPermission(PERM_PLACEHOLDERS)) {
+			sender.sendMessage(ChatColor.RED + "You don't have permission to view placeholders.");
+			return;
+		}
+
+		sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "TimeManager placeholders");
+		sender.sendMessage(ChatColor.GRAY + "PAPI form: " + ChatColor.YELLOW + "%" + PH_PREFIX + "<name>%"
+				+ ChatColor.GRAY + "   In-message form: " + ChatColor.YELLOW + "{" + PH_PREFIX + "<name>}");
+		sender.sendMessage(ChatColor.GRAY + "-------------------------------------------------------");
+
+		for (String[] row : ROWS) {
+			sender.sendMessage(
+					ChatColor.YELLOW + "%" + PH_PREFIX + row[0] + "%"
+					+ ChatColor.DARK_GRAY + "  —  "
+					+ ChatColor.GRAY + row[1]);
+		}
+
+		sender.sendMessage(ChatColor.GRAY + "-------------------------------------------------------");
+		sender.sendMessage(ChatColor.GRAY + "Total: " + ChatColor.YELLOW + ROWS.length + ChatColor.GRAY + " placeholders.");
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmUnlock.java
+++ b/src/net/vdcraft/arvdc/timemanager/cmdadmin/TmUnlock.java
@@ -1,0 +1,53 @@
+package net.vdcraft.arvdc.timemanager.cmdadmin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.mainclass.LockTimeHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.MsgHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.SpeedHandler;
+import net.vdcraft.arvdc.timemanager.mainclass.SyncHandler;
+
+/**
+ * /tm unlock &lt;world&gt;
+ *
+ * Removes a {@code lock-time} entry from a world. The world keeps whatever
+ * (start, daySpeed, nightSpeed, firstStartTime) the lock had written to the
+ * config — admins are expected to set the desired speed afterwards if they
+ * want the world to resume normal day/night progression.
+ */
+public class TmUnlock extends MainTM {
+
+	public static void cmdUnlock(CommandSender sender, String world) {
+
+		// #1. Validate
+		if (Bukkit.getWorld(world) == null) {
+			MsgHandler.cmdErrorMsg(sender, "§cUnknown world: §e" + world + "§c.", CMD_UNLOCK);
+			return;
+		}
+		if (!MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false).contains(world)) {
+			MsgHandler.cmdErrorMsg(sender, "§cUnknown world: §e" + world + "§c.", CMD_UNLOCK);
+			return;
+		}
+
+		String lockKey = CF_WORLDSLIST + "." + world + "." + CF_LOCKTIME;
+		if (!MainTM.getInstance().getConfig().contains(lockKey)) {
+			MsgHandler.playerAdminMsg(sender, "World §e" + world + "§r has no lock-time set.");
+			return;
+		}
+
+		// #2. Clear the lock-time key
+		LockTimeHandler.clearLockTime(world);
+		MainTM.getInstance().saveConfig();
+
+		// #3. Re-apply scheduler / sync so the speed change takes effect
+		SyncHandler.worldSync(sender, world, ARG_START);
+		SpeedHandler.speedScheduler(world);
+
+		// #4. Notify
+		MsgHandler.infoMsg("The world §e" + world + "§r has been unlocked.");
+		MsgHandler.playerAdminMsg(sender,
+				"Unlocked §e" + world + "§r. Use §e/tm set daySpeed/nightSpeed §rto restore normal time flow.");
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/ActionBarHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/ActionBarHandler.java
@@ -1,0 +1,145 @@
+package net.vdcraft.arvdc.timemanager.mainclass;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.cmdplayer.PlayerLangHandler;
+import net.vdcraft.arvdc.timemanager.placeholders.PlaceholdersHandler;
+
+/**
+ * Optional ActionBar HUD that broadcasts a configurable time/day string to
+ * online players. Disabled by default — admins enable via
+ * {@code hud.actionbar.enabled: true} in config.yml.
+ *
+ * Config keys:
+ * <pre>
+ * hud:
+ *   actionbar:
+ *     enabled: false
+ *     refresh-rate: 20        # ticks between updates
+ *     format: "&7%tm_time24% &8| &eDay %tm_serverday%"
+ *     worlds: []              # empty list = all worlds; otherwise list world names
+ * </pre>
+ *
+ * Players can opt out individually with {@code /tm hud off} (in-memory only —
+ * preference resets on restart, kept intentionally simple).
+ */
+public class ActionBarHandler {
+
+	private static final String CF_HUD_ENABLED = "hud.actionbar.enabled";
+	private static final String CF_HUD_REFRESH = "hud.actionbar.refresh-rate";
+	private static final String CF_HUD_FORMAT  = "hud.actionbar.format";
+	private static final String CF_HUD_WORLDS  = "hud.actionbar.worlds";
+
+	/** Players who explicitly opted out via /tm hud off. */
+	private static final Set<UUID> optedOut = new HashSet<>();
+	private static int taskId = -1;
+
+	/**
+	 * Ensure the HUD-related config keys exist with defaults. Called from
+	 * {@link CfgFileHandler}.
+	 */
+	public static void ensureDefaults() {
+		if (!MainTM.getInstance().getConfig().contains(CF_HUD_ENABLED)) {
+			MainTM.getInstance().getConfig().set(CF_HUD_ENABLED, false);
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_HUD_REFRESH)) {
+			MainTM.getInstance().getConfig().set(CF_HUD_REFRESH, 20);
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_HUD_FORMAT)) {
+			MainTM.getInstance().getConfig().set(CF_HUD_FORMAT,
+					"&7{tm_time24} &8| &eDay {tm_serverday}");
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_HUD_WORLDS)) {
+			MainTM.getInstance().getConfig().set(CF_HUD_WORLDS, new java.util.ArrayList<String>());
+		}
+	}
+
+	/** Start or restart the broadcasting task based on current config. */
+	public static void startOrRestart() {
+		// Cancel previous task if any
+		if (taskId != -1) {
+			Bukkit.getScheduler().cancelTask(taskId);
+			taskId = -1;
+		}
+		if (!MainTM.getInstance().getConfig().getBoolean(CF_HUD_ENABLED, false)) {
+			return;
+		}
+		int refresh = Math.max(5, MainTM.getInstance().getConfig().getInt(CF_HUD_REFRESH, 20));
+		taskId = new BukkitRunnable() {
+			@Override
+			public void run() { broadcast(); }
+		}.runTaskTimer(MainTM.getInstance(), refresh, refresh).getTaskId();
+	}
+
+	/** Send one round of action bars to all eligible players. */
+	private static void broadcast() {
+		String format = MainTM.getInstance().getConfig().getString(CF_HUD_FORMAT,
+				"&7{tm_time24} &8| &eDay {tm_serverday}");
+		List<String> worldsFilter = MainTM.getInstance().getConfig().getStringList(CF_HUD_WORLDS);
+
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			if (optedOut.contains(p.getUniqueId())) continue;
+			String world = p.getWorld().getName();
+			if (!worldsFilter.isEmpty() && !worldsFilter.contains(world)) continue;
+
+			// Resolve plugin placeholders (no PAPI dependency) — supports
+			// curly-brace {tm_X} form.
+			String lang = PlayerLangHandler.setLangToUse(p);
+			String resolved = format;
+			// Substitute every known placeholder. Done by calling the central
+			// PlaceholdersHandler once per occurrence — cheap, format strings
+			// are short.
+			resolved = resolveAll(resolved, world, lang, p);
+			// Legacy color codes (&7 etc.)
+			resolved = ChatColor.translateAlternateColorCodes('&', resolved);
+
+			p.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(resolved));
+		}
+	}
+
+	private static String resolveAll(String input, String world, String lang, Player p) {
+		// Quick scan for {tm_*} occurrences and replace each via
+		// PlaceholdersHandler. Avoids per-tick regex compile cost by using
+		// indexOf / substring.
+		int pos = 0;
+		StringBuilder out = new StringBuilder(input.length());
+		while (true) {
+			int open = input.indexOf("{" + MainTM.PH_PREFIX, pos);
+			if (open < 0) {
+				out.append(input, pos, input.length());
+				break;
+			}
+			int close = input.indexOf('}', open + 1);
+			if (close < 0) { // unterminated — bail
+				out.append(input, pos, input.length());
+				break;
+			}
+			out.append(input, pos, open);
+			String token = input.substring(open, close + 1);
+			String resolved = PlaceholdersHandler.replacePlaceholder(token, world, lang, p);
+			if (resolved == null) resolved = token; // unknown — leave literal
+			out.append(resolved);
+			pos = close + 1;
+		}
+		return out.toString();
+	}
+
+	public static void setOptOut(UUID uuid, boolean off) {
+		if (off) optedOut.add(uuid); else optedOut.remove(uuid);
+	}
+
+	public static boolean isOptedOut(UUID uuid) {
+		return optedOut.contains(uuid);
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/CfgFileHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/CfgFileHandler.java
@@ -106,6 +106,11 @@ public class CfgFileHandler extends MainTM {
 		WorldListHandler.listLoadedWorlds();
 		// #9.B. For each world
 		for (String world : MainTM.getInstance().getConfig().getConfigurationSection(CF_WORLDSLIST).getKeys(false)) {
+			// #9.A.0. Expand `lock-time` shortcut into the underlying
+			//         (start, daySpeed, nightSpeed, firstStartTime) tuple.
+			//         Must run BEFORE the restrain* calls so the derived
+			//         values get validated/clamped like manually-set ones.
+			LockTimeHandler.applyLockTime(world);
 			// #9.A. Restrain the start times
 			ValuesConverter.restrainStart(world);
 			// #9.B. Restrain the speed modifiers
@@ -132,6 +137,17 @@ public class CfgFileHandler extends MainTM {
 			}
 		} else {
 			MainTM.getInstance().getConfig().set(CF_INITIALTICK + "." + CF_RESETONSTARTUP, ARG_TRUE);
+		}
+
+		// #10.A.a-bis. firstEverTickNb — written ONCE on first plugin enable and
+		//   never reset thereafter. Used by %tm_serverday%. We deliberately
+		//   ignore resetOnStartup for this value, so admins can keep their
+		//   existing initialTick reset behaviour but still get a meaningful
+		//   "days since I installed TimeManager" counter.
+		if (!MainTM.getInstance().getConfig().contains(CF_INITIALTICK + "." + CF_FIRSTEVERTICK)) {
+			MainTM.getInstance().getConfig().set(
+					CF_INITIALTICK + "." + CF_FIRSTEVERTICK,
+					ValuesConverter.getServerTick());
 		}
 
 		// #10.A.b. useMySql value
@@ -187,6 +203,10 @@ public class CfgFileHandler extends MainTM {
 		} else {
 			MainTM.getInstance().getConfig().set(CF_PLACEHOLDERS + "." + CF_PLACEHOLDER_CMDS, ARG_FALSE);
 		}
+
+		// #13.B. Ensure ActionBar HUD defaults exist + (re)start its task
+		ActionBarHandler.ensureDefaults();
+		ActionBarHandler.startOrRestart();
 
 		// #14. Restore debugMode node location
 		DebugModeHandler.debugModeNodeRelocate();

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/LockTimeHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/LockTimeHandler.java
@@ -1,0 +1,91 @@
+package net.vdcraft.arvdc.timemanager.mainclass;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+
+/**
+ * Convenience single-key shortcut for locking or speeding up a world.
+ *
+ * Admins set {@code lock-time:} on a world inside {@code worldsList}, and on
+ * config load the plugin translates that single key into the equivalent
+ * (start, daySpeed, nightSpeed, firstStartTime) combination that the rest of
+ * the plugin already understands. The original {@code lock-time} key stays in
+ * the config as the source of truth — the derived values are written back so
+ * older parts of the plugin (and human readers) can still see what the world
+ * is doing.
+ *
+ * Supported values:
+ * <ul>
+ *   <li>{@code noon} / {@code midday} – tick 6000, frozen</li>
+ *   <li>{@code dawn} / {@code sunrise} / {@code morning} – tick 0, frozen</li>
+ *   <li>{@code dusk} / {@code sunset} / {@code evening} – tick 12000, frozen</li>
+ *   <li>{@code day} – tick 1000, frozen</li>
+ *   <li>{@code night} – tick 13000, frozen</li>
+ *   <li>{@code midnight} – tick 18000, frozen</li>
+ *   <li>{@code 0}–{@code 23999} – exact tick, frozen</li>
+ *   <li>{@code HH:mm} (e.g. {@code 13:30}) – frozen at the matching tick</li>
+ *   <li>{@code realtime} – follow UTC clock (speed = 24.0)</li>
+ *   <li>{@code false} / {@code off} / unset – no override</li>
+ * </ul>
+ */
+public class LockTimeHandler extends MainTM {
+
+	/**
+	 * If a world has {@code lock-time} set, expand it into the equivalent
+	 * speed/start combination and persist the derived values. Called once
+	 * per world during {@link CfgFileHandler#loadConfig(String)}.
+	 */
+	public static void applyLockTime(String world) {
+		String key = CF_WORLDSLIST + "." + world + "." + CF_LOCKTIME;
+		if (!MainTM.getInstance().getConfig().contains(key)) return;
+
+		String raw = MainTM.getInstance().getConfig().getString(key);
+		if (raw == null || raw.isEmpty()
+				|| raw.equalsIgnoreCase(ARG_FALSE)
+				|| raw.equalsIgnoreCase("off")
+				|| raw.equalsIgnoreCase("none")) {
+			return;
+		}
+
+		String base = CF_WORLDSLIST + "." + world + ".";
+
+		// "realtime" — sync world clock to UTC (24h cycle in 24h real time).
+		if (raw.equalsIgnoreCase("realtime")) {
+			MainTM.getInstance().getConfig().set(base + CF_D_SPEED, realtimeSpeed);
+			MainTM.getInstance().getConfig().set(base + CF_N_SPEED, realtimeSpeed);
+			MsgHandler.debugMsg("lock-time on §e" + world + "§b: realtime (speed=24.0).");
+			return;
+		}
+
+		// Frozen at a specific tick.
+		Long tick = ValuesConverter.tickFromString(raw);
+		if (tick == null) tick = 6000L; // shouldn't happen — tickFromString never returns null
+
+		MainTM.getInstance().getConfig().set(base + CF_START, tick);
+		MainTM.getInstance().getConfig().set(base + CF_D_SPEED, 0.0);
+		MainTM.getInstance().getConfig().set(base + CF_N_SPEED, 0.0);
+		MainTM.getInstance().getConfig().set(base + CF_FIRSTSTARTTIME, ARG_START);
+
+		MsgHandler.debugMsg("lock-time on §e" + world + "§b: locked at tick " + tick + ".");
+	}
+
+	/**
+	 * Set or update the lock-time entry for a world at runtime (e.g. from
+	 * {@code /tm lock <world> <time>} command). Writes config without saving;
+	 * caller should follow with {@code MainTM.getInstance().saveConfig()}.
+	 */
+	public static void setLockTime(String world, String value) {
+		MainTM.getInstance().getConfig().set(
+				CF_WORLDSLIST + "." + world + "." + CF_LOCKTIME, value);
+		applyLockTime(world);
+	}
+
+	/**
+	 * Remove lock-time on a world. Does NOT restore previous speeds — caller
+	 * (e.g. /tm unlock) decides what defaults to write back, since we don't
+	 * keep a snapshot.
+	 */
+	public static void clearLockTime(String world) {
+		MainTM.getInstance().getConfig().set(
+				CF_WORLDSLIST + "." + world + "." + CF_LOCKTIME, null);
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/NowItemHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/NowItemHandler.java
@@ -1,0 +1,138 @@
+package net.vdcraft.arvdc.timemanager.mainclass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.cmdadmin.TmNow;
+
+/**
+ * Custom "pocket watch" item that runs the {@code /now} action on right-click.
+ *
+ * Implementation:
+ * <ul>
+ *   <li>Item is a {@link Material#CLOCK} with a PersistentDataContainer flag
+ *       under namespace {@code timemanager:now-item}.</li>
+ *   <li>{@link #createItem()} builds a fresh stack with display name + lore.</li>
+ *   <li>{@link #onUse(PlayerInteractEvent)} catches right-click on this item
+ *       and calls {@link TmNow} so the player gets the same chat/title output
+ *       as {@code /tm now}.</li>
+ * </ul>
+ *
+ * Config keys (under root):
+ * <pre>
+ * now-item:
+ *   enabled: true
+ *   display-name: "&#FFD700&l✦ Pocket Watch"
+ *   lore:
+ *     - "&7Right-click to check the current time"
+ *   cooldown-ticks: 20   # client cooldown after each use
+ * </pre>
+ *
+ * Admin command: {@code /tm nowitem} gives one to the executing player. The
+ * command lives inside {@link net.vdcraft.arvdc.timemanager.cmdadmin.TmNowItem}.
+ */
+public class NowItemHandler implements Listener {
+
+	private static final String CF_NOW_ITEM_ENABLED = "now-item.enabled";
+	private static final String CF_NOW_ITEM_NAME    = "now-item.display-name";
+	private static final String CF_NOW_ITEM_LORE    = "now-item.lore";
+	private static final String CF_NOW_ITEM_CD      = "now-item.cooldown-ticks";
+
+	/** PDC key on the item to identify it as a TimeManager now-item. */
+	public static NamespacedKey markerKey() {
+		return new NamespacedKey(MainTM.getInstance(), "now-item");
+	}
+
+	public static void ensureDefaults() {
+		if (!MainTM.getInstance().getConfig().contains(CF_NOW_ITEM_ENABLED)) {
+			MainTM.getInstance().getConfig().set(CF_NOW_ITEM_ENABLED, true);
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_NOW_ITEM_NAME)) {
+			MainTM.getInstance().getConfig().set(CF_NOW_ITEM_NAME, "&6&l✦ Pocket Watch");
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_NOW_ITEM_LORE)) {
+			List<String> defLore = new ArrayList<>();
+			defLore.add("&7Right-click to check the time.");
+			MainTM.getInstance().getConfig().set(CF_NOW_ITEM_LORE, defLore);
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_NOW_ITEM_CD)) {
+			MainTM.getInstance().getConfig().set(CF_NOW_ITEM_CD, 20);
+		}
+	}
+
+	/** Build a fresh pocket-watch ItemStack. */
+	public static ItemStack createItem() {
+		ItemStack stack = new ItemStack(Material.CLOCK, 1);
+		ItemMeta meta = stack.getItemMeta();
+		if (meta != null) {
+			String name = MainTM.getInstance().getConfig().getString(CF_NOW_ITEM_NAME,
+					"&6&l✦ Pocket Watch");
+			meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+
+			List<String> loreRaw = MainTM.getInstance().getConfig().getStringList(CF_NOW_ITEM_LORE);
+			List<String> lore = new ArrayList<>(loreRaw.size());
+			for (String l : loreRaw) lore.add(ChatColor.translateAlternateColorCodes('&', l));
+			meta.setLore(lore);
+
+			PersistentDataContainer pdc = meta.getPersistentDataContainer();
+			pdc.set(markerKey(), PersistentDataType.BYTE, (byte) 1);
+
+			stack.setItemMeta(meta);
+		}
+		return stack;
+	}
+
+	/** Check whether a stack is a TimeManager now-item. */
+	public static boolean isNowItem(ItemStack stack) {
+		if (stack == null || stack.getType() != Material.CLOCK) return false;
+		ItemMeta meta = stack.getItemMeta();
+		if (meta == null) return false;
+		PersistentDataContainer pdc = meta.getPersistentDataContainer();
+		return pdc.has(markerKey(), PersistentDataType.BYTE);
+	}
+
+	@EventHandler
+	public void onUse(PlayerInteractEvent e) {
+		if (!MainTM.getInstance().getConfig().getBoolean(CF_NOW_ITEM_ENABLED, true)) return;
+		if (e.getHand() == null) return;
+		if (!e.getAction().name().startsWith("RIGHT_CLICK")) return;
+
+		Player p = e.getPlayer();
+		ItemStack stack = p.getInventory().getItem(e.getHand());
+		if (!isNowItem(stack)) return;
+
+		if (!p.hasPermission("timemanager.now-item.use")) {
+			p.sendMessage(ChatColor.RED + "You don't have permission to use this item.");
+			return;
+		}
+
+		// Apply a short cooldown on the CLOCK material so the player can't
+		// spam right-click. Cooldown is per-player on the Material.
+		int cd = MainTM.getInstance().getConfig().getInt(CF_NOW_ITEM_CD, 20);
+		if (p.hasCooldown(Material.CLOCK)) return;
+		if (cd > 0) p.setCooldown(Material.CLOCK, cd);
+
+		// Trigger the same output as /tm now msg <player> (chat message)
+		try {
+			TmNow.cmdNow((CommandSender) p, "msg", p.getName());
+		} catch (Throwable t) {
+			// Fallback: a minimal direct line if TmNow throws (e.g. missing
+			// language file key).
+			p.sendMessage(ChatColor.GOLD + "Tick: " + ChatColor.YELLOW + p.getWorld().getTime());
+		}
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/RefreshingSignHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/RefreshingSignHandler.java
@@ -1,0 +1,265 @@
+package net.vdcraft.arvdc.timemanager.mainclass;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+import org.bukkit.block.sign.SignSide;
+import org.bukkit.block.sign.Side;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import net.vdcraft.arvdc.timemanager.MainTM;
+import net.vdcraft.arvdc.timemanager.cmdplayer.PlayerLangHandler;
+import net.vdcraft.arvdc.timemanager.placeholders.PlaceholdersHandler;
+
+/**
+ * Refreshing signs — players place a sign whose first line is the marker
+ * {@code [tm]} (case-insensitive) and the remaining 3 lines may contain any
+ * combination of plain text and {curly-brace} placeholders such as
+ * {@code {tm_time24}}, {@code {tm_serverday}}. The plugin then rewrites the
+ * sign's text on a configurable interval so it acts as a live clock / day
+ * counter in-world.
+ *
+ * Config keys (under root):
+ * <pre>
+ * signs:
+ *   enabled: true
+ *   refresh-rate: 40    # ticks
+ *   marker: "[tm]"      # first-line marker that turns a sign into a TM sign
+ * </pre>
+ *
+ * Persistence: registered sign coordinates are written to {@code signs.yml}
+ * inside the plugin folder so they survive restart.
+ */
+public class RefreshingSignHandler implements Listener {
+
+	private static final String CF_SIGNS_ENABLED = "signs.enabled";
+	private static final String CF_SIGNS_REFRESH = "signs.refresh-rate";
+	private static final String CF_SIGNS_MARKER  = "signs.marker";
+
+	/** In-memory cache of tracked signs, keyed by "<world>:<x>,<y>,<z>". */
+	private static final Set<String> tracked = new HashSet<>();
+	/** Original line2..4 text (with placeholders) per sign key. */
+	private static final java.util.Map<String, String[]> templates = new java.util.HashMap<>();
+	private static int taskId = -1;
+	private static File signsFile;
+
+	/** Wire-up: ensure config defaults, load persisted signs, start task. */
+	public static void init() {
+		ensureDefaults();
+		signsFile = new File(MainTM.getInstance().getDataFolder(), "signs.yml");
+		loadFromDisk();
+		startOrRestart();
+	}
+
+	private static void ensureDefaults() {
+		if (!MainTM.getInstance().getConfig().contains(CF_SIGNS_ENABLED)) {
+			MainTM.getInstance().getConfig().set(CF_SIGNS_ENABLED, true);
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_SIGNS_REFRESH)) {
+			MainTM.getInstance().getConfig().set(CF_SIGNS_REFRESH, 40);
+		}
+		if (!MainTM.getInstance().getConfig().contains(CF_SIGNS_MARKER)) {
+			MainTM.getInstance().getConfig().set(CF_SIGNS_MARKER, "[tm]");
+		}
+	}
+
+	public static void startOrRestart() {
+		if (taskId != -1) {
+			Bukkit.getScheduler().cancelTask(taskId);
+			taskId = -1;
+		}
+		if (!MainTM.getInstance().getConfig().getBoolean(CF_SIGNS_ENABLED, true)) return;
+
+		int refresh = Math.max(5, MainTM.getInstance().getConfig().getInt(CF_SIGNS_REFRESH, 40));
+		taskId = new BukkitRunnable() {
+			@Override
+			public void run() { refreshAll(); }
+		}.runTaskTimer(MainTM.getInstance(), refresh, refresh).getTaskId();
+	}
+
+	/* ─────────────── Persistence ─────────────── */
+
+	private static void loadFromDisk() {
+		tracked.clear();
+		templates.clear();
+		if (signsFile == null || !signsFile.exists()) return;
+		YamlConfiguration y = YamlConfiguration.loadConfiguration(signsFile);
+		ConfigurationSection root = y.getConfigurationSection("signsList");
+		if (root == null) return;
+		for (String id : root.getKeys(false)) {
+			ConfigurationSection s = root.getConfigurationSection(id);
+			if (s == null) continue;
+			String world = s.getString("world");
+			String pos = s.getString("position");
+			if (world == null || pos == null || pos.isEmpty()) continue;
+			String[] xyz = pos.replace(" ", "").split(",");
+			if (xyz.length != 3) continue;
+			String key = world + ":" + xyz[0] + "," + xyz[1] + "," + xyz[2];
+			tracked.add(key);
+			ConfigurationSection content = s.getConfigurationSection("content");
+			if (content != null) {
+				String[] tpl = new String[3];
+				tpl[0] = content.getString("line2", "");
+				tpl[1] = content.getString("line3", "");
+				tpl[2] = content.getString("line4", "");
+				templates.put(key, tpl);
+			}
+		}
+		MsgHandler.infoMsg("Loaded " + tracked.size() + " refreshing sign(s) from disk.");
+	}
+
+	private static void saveToDisk() {
+		if (signsFile == null) return;
+		YamlConfiguration y = new YamlConfiguration();
+		int i = 1;
+		for (String key : tracked) {
+			int colon = key.indexOf(':');
+			String world = key.substring(0, colon);
+			String pos = key.substring(colon + 1);
+			String base = "signsList." + String.format("%02d", i++);
+			y.set(base + ".world", world);
+			y.set(base + ".position", pos);
+			String[] tpl = templates.get(key);
+			if (tpl != null) {
+				y.set(base + ".content.line1", "[tm]");
+				y.set(base + ".content.line2", tpl[0]);
+				y.set(base + ".content.line3", tpl[1]);
+				y.set(base + ".content.line4", tpl[2]);
+			}
+		}
+		try {
+			y.save(signsFile);
+		} catch (IOException e) {
+			MsgHandler.errorMsg("Failed to save signs.yml: " + e.getMessage());
+		}
+	}
+
+	/* ─────────────── Periodic refresh ─────────────── */
+
+	private static void refreshAll() {
+		if (tracked.isEmpty()) return;
+		List<String> stale = new ArrayList<>();
+		for (String key : tracked) {
+			int colon = key.indexOf(':');
+			String worldName = key.substring(0, colon);
+			String[] xyz = key.substring(colon + 1).split(",");
+			World w = Bukkit.getWorld(worldName);
+			if (w == null) continue;
+			int x, y, z;
+			try {
+				x = Integer.parseInt(xyz[0]);
+				y = Integer.parseInt(xyz[1]);
+				z = Integer.parseInt(xyz[2]);
+			} catch (NumberFormatException nfe) {
+				stale.add(key); continue;
+			}
+			Block b = w.getBlockAt(x, y, z);
+			if (!(b.getState() instanceof Sign)) {
+				stale.add(key); continue; // sign broken or replaced
+			}
+			Sign sign = (Sign) b.getState();
+			String[] tpl = templates.get(key);
+			if (tpl == null) continue;
+			SignSide side = sign.getSide(Side.FRONT);
+			side.setLine(0, ChatColor.translateAlternateColorCodes('&',
+					MainTM.getInstance().getConfig().getString(CF_SIGNS_MARKER, "[tm]")));
+			side.setLine(1, resolve(tpl[0], worldName));
+			side.setLine(2, resolve(tpl[1], worldName));
+			side.setLine(3, resolve(tpl[2], worldName));
+			sign.update(false, false);
+		}
+		if (!stale.isEmpty()) {
+			tracked.removeAll(stale);
+			for (String s : stale) templates.remove(s);
+			saveToDisk();
+		}
+	}
+
+	private static String resolve(String line, String world) {
+		if (line == null || line.isEmpty()) return "";
+		String lang = "en";
+		// World-context only — no player here.
+		int pos = 0;
+		StringBuilder out = new StringBuilder(line.length());
+		while (true) {
+			int open = line.indexOf("{" + MainTM.PH_PREFIX, pos);
+			if (open < 0) {
+				out.append(line, pos, line.length());
+				break;
+			}
+			int close = line.indexOf('}', open + 1);
+			if (close < 0) {
+				out.append(line, pos, line.length());
+				break;
+			}
+			out.append(line, pos, open);
+			String token = line.substring(open, close + 1);
+			String resolved;
+			try {
+				resolved = PlaceholdersHandler.replacePlaceholder(token, world, lang, null);
+			} catch (Throwable t) {
+				resolved = token;
+			}
+			out.append(resolved == null ? token : resolved);
+			pos = close + 1;
+		}
+		return ChatColor.translateAlternateColorCodes('&', out.toString());
+	}
+
+	/* ─────────────── Listeners ─────────────── */
+
+	@EventHandler
+	public void onSignChange(SignChangeEvent e) {
+		String marker = MainTM.getInstance().getConfig().getString(CF_SIGNS_MARKER, "[tm]");
+		String line0 = ChatColor.stripColor(e.getLine(0) == null ? "" : e.getLine(0)).trim();
+		if (!line0.equalsIgnoreCase(marker)) return;
+
+		Player p = e.getPlayer();
+		if (!p.hasPermission("timemanager.signs.create")) {
+			p.sendMessage(ChatColor.RED + "You don't have permission to create TimeManager signs.");
+			e.setLine(0, "");
+			return;
+		}
+
+		Block b = e.getBlock();
+		String key = b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
+		tracked.add(key);
+		templates.put(key, new String[] {
+				e.getLine(1) == null ? "" : e.getLine(1),
+				e.getLine(2) == null ? "" : e.getLine(2),
+				e.getLine(3) == null ? "" : e.getLine(3),
+		});
+		saveToDisk();
+		p.sendMessage(ChatColor.GOLD + "TimeManager sign registered. Placeholders will refresh automatically.");
+	}
+
+	@EventHandler
+	public void onBlockBreak(BlockBreakEvent e) {
+		Block b = e.getBlock();
+		Material m = b.getType();
+		if (!m.name().endsWith("_SIGN") && !m.name().endsWith("_WALL_SIGN")) return;
+		String key = b.getWorld().getName() + ":" + b.getX() + "," + b.getY() + "," + b.getZ();
+		if (tracked.remove(key)) {
+			templates.remove(key);
+			saveToDisk();
+		}
+	}
+}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/SleepHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/SleepHandler.java
@@ -181,7 +181,7 @@ public class SleepHandler implements Listener {
 		// Artificially change world's fulltime
 		long wakeUpTick = MainTM.getInstance().getConfig().getLong(MainTM.CF_WAKEUPTICK);
 		long ft = w.getFullTime();
-		w.setFullTime(ft - (ft % 24000) + 24000 + wakeUpTick);
+		SyncHandler.safeSetFullTime(w.getName(), ft - (ft % 24000) + 24000 + wakeUpTick);
 		MsgHandler.debugMsg(MainTM.sleepFulltimeTickDebugMsg + ft + "§b. New fulltime is §e#" + w.getFullTime() + "§b."); // Console debug msg
 		// Use relevant day speed in the world
 		SpeedHandler.speedScheduler(world);
@@ -440,6 +440,34 @@ public class SleepHandler implements Listener {
 				break;
 		}
 		p.spawnParticle(Particle.DUST_COLOR_TRANSITION, loc, 60, 1, 1, 1, dustTransition);
+
+		// Sleep-animation enhancements — additional particle layers per phase
+		// so the wake-up climax feels visually distinct from early sleep dust.
+		// Wrapped in a flag so admins who liked the old subtle look can keep it.
+		if (!MainTM.getInstance().getConfig().getBoolean("sleep.enhanced-particles", true)) return;
+		try {
+			switch (iterationNb) {
+				default:
+				case 4 : // early sleep — gentle floating sparkles
+					p.spawnParticle(Particle.END_ROD, loc, 6, 0.4, 0.4, 0.4, 0.005);
+					break;
+				case 3 : // middle — denser sparkles
+					p.spawnParticle(Particle.END_ROD, loc, 15, 0.6, 0.6, 0.6, 0.01);
+					break;
+				case 2 : // pre-climax — sparkle cloud
+					p.spawnParticle(Particle.END_ROD, loc, 30, 0.9, 0.9, 0.9, 0.02);
+					p.spawnParticle(Particle.GLOW, loc, 10, 0.7, 0.7, 0.7, 0.0);
+					break;
+				case 1 : // wake-up climax — bigger burst + firework dust
+					p.spawnParticle(Particle.END_ROD, loc, 60, 1.0, 1.0, 1.0, 0.05);
+					p.spawnParticle(Particle.FIREWORK, loc, 25, 0.8, 0.8, 0.8, 0.12);
+					p.spawnParticle(Particle.GLOW, loc, 20, 1.0, 1.0, 1.0, 0.0);
+					break;
+			}
+		} catch (Throwable t) {
+			// Older Bukkit builds may not have GLOW or rename particles —
+			// fall back silently. The base DUST_COLOR_TRANSITION already ran.
+		}
 	}
 	
 	/**
@@ -498,7 +526,7 @@ public class SleepHandler implements Listener {
 	private static void linkedSleep(String world, Long refFulltime) {
 		for (String linkedWorld : MainTM.getInstance().getConfig().getConfigurationSection(MainTM.CF_WORLDSLIST).getKeys(false)) {
 			String linkedSleep = MainTM.getInstance().getConfig().getString(MainTM.CF_WORLDSLIST + "." + linkedWorld + "." + MainTM.CF_SLEEP);
-			if (linkedSleep.equalsIgnoreCase(MainTM.ARG_LINKED) && !linkedWorld.equalsIgnoreCase(world)) Bukkit.getWorld(linkedWorld).setFullTime(refFulltime);
+			if (linkedSleep.equalsIgnoreCase(MainTM.ARG_LINKED) && !linkedWorld.equalsIgnoreCase(world)) SyncHandler.safeSetFullTime(linkedWorld, refFulltime);
 			// Notify the console
 			MsgHandler.infoMsg("The world " + linkedWorld + " " + MainTM.sleepLinkedNewDayMsg); // Console final msg
 		}

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/SpeedHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/SpeedHandler.java
@@ -137,7 +137,7 @@ public class SpeedHandler extends MainTM {
 					// Restrain too big and too small values
 					newTime = ValuesConverter.correctDailyTicks(newTime);				
 					// Change world's timer
-					Bukkit.getWorld(world).setTime(newTime);
+					SyncHandler.safeSetTime(world, newTime);
 					// While the world is not cancelled and the speed still 24h, launch the loop again ...
 					if (speed == realtimeSpeed) {
 						realSpeedScheduler(world);
@@ -191,7 +191,7 @@ public class SpeedHandler extends MainTM {
 					// Restrain too big and too small values
 					newTime = ValuesConverter.correctDailyTicks(newTime);
 					// Change the world's time
-					Bukkit.getWorld(world).setTime(newTime);
+					SyncHandler.safeSetTime(world, newTime);
 					// Change the doDaylightCycle gamerule if it is needed
 					double newSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(newTime));
 					if ((currentSpeed <= 1 && newSpeed > 1) || (currentSpeed > 1 && newSpeed <= 1))
@@ -262,7 +262,7 @@ public class SpeedHandler extends MainTM {
 					// Restrain too big and too small values
 					newTime = ValuesConverter.correctDailyTicks(newTime);
 					// Change the world's time
-					Bukkit.getWorld(world).setTime(newTime);
+					SyncHandler.safeSetTime(world, newTime);
 					// Change the doDaylightCycle gamerule if it is needed
 					double newSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(newTime));
 					if ((currentSpeed <= 1 && newSpeed > 1) || (currentSpeed > 1 && newSpeed <= 1))
@@ -318,7 +318,7 @@ public class SpeedHandler extends MainTM {
 					// Restrain too big and too small values
 					newTime = ValuesConverter.correctDailyTicks(newTime);
 					// Change the world's time
-					Bukkit.getWorld(world).setTime(newTime);
+					SyncHandler.safeSetTime(world, newTime);
 					// Change the doDaylightCycle gamerule if it is needed
 					double newSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(newTime));
 					if (newSpeed < 1) DoDaylightCycleHandler.adjustDaylightCycle(world);
@@ -370,7 +370,7 @@ public class SpeedHandler extends MainTM {
 					// Restrain too big and too small values
 					newTime = ValuesConverter.correctDailyTicks(newTime);
 					// Change the world's time
-					Bukkit.getWorld(world).setTime(newTime);
+					SyncHandler.safeSetTime(world, newTime);
 					// Change the doDaylightCycle gamerule if it is needed
 					double newSpeed = MainTM.getInstance().getConfig().getDouble(CF_WORLDSLIST + "." + world + "." + ValuesConverter.wichSpeedParam(newTime));
 					if (newSpeed >= 1) DoDaylightCycleHandler.adjustDaylightCycle(world);

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/SyncHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/SyncHandler.java
@@ -172,14 +172,26 @@ public class SyncHandler extends MainTM {
 
 			// #2.H. Apply modifications
 			newTime = ValuesConverter.correctDailyTicks(newTime);
-			Bukkit.getServer().getWorld(world).setTime(newTime);
+			// Skip the setTime/setFullTime calls when the world is frozen and
+			// already sitting at the target tick — they would be no-ops anyway,
+			// but on Paper builds where the world's tick rate manager is not
+			// running normally (datapack dimension, /tick freeze, etc.) the
+			// call throws IllegalArgumentException("Cannot set time in world
+			// without world clock"). safeSetTime() handles that fallback.
+			long worldCurrentTime = Bukkit.getServer().getWorld(world).getTime();
+			boolean alreadyLocked = (speed == 0.0 && worldCurrentTime == newTime);
+
+			if (!alreadyLocked) {
+				safeSetTime(world, newTime);
+			}
 
 			// #2.I. Adjust doDaylightCycle value
 			DoDaylightCycleHandler.adjustDaylightCycle(world);
-			
+
 			// #2.J. Restore the number of elapsed days
-			Long nft = (initElapsedDays * 24000) + newTime;
-			Bukkit.getWorld(world).setFullTime(nft);
+			if (!alreadyLocked) {
+				safeSetFullTime(world, (initElapsedDays * 24000) + newTime);
+			}
 
 			// #2.K. Extra notifications (for each cases)
 			String listedWorldStartTime = ValuesConverter.formattedTimeFromTick(startAtTickNb, true);
@@ -299,6 +311,38 @@ public class SyncHandler extends MainTM {
 			}
 		} 
 		return newTime;
+	}
+
+	/**
+	 * Bukkit's setTime() / setFullTime() throw IllegalArgumentException
+	 * ("Cannot set time in world without world clock") on Paper when the
+	 * world's tick rate manager is not running normally — e.g. datapack
+	 * dimensions, /tick freeze, or worlds whose doDaylightCycle gamerule has
+	 * been forced off in a way that disables the clock entirely.
+	 *
+	 * Our scheduler / sync paths call these every refresh cycle, so a thrown
+	 * exception would spam the console (and kill the BukkitScheduler task on
+	 * first throw). Wrap the calls so we degrade gracefully: log only in
+	 * debug mode, otherwise stay silent.
+	 */
+	public static void safeSetTime(String world, long tick) {
+		World w = Bukkit.getWorld(world);
+		if (w == null) return;
+		try {
+			w.setTime(tick);
+		} catch (IllegalArgumentException e) {
+			MsgHandler.debugMsg("Skipping setTime for §e" + world + "§b: " + e.getMessage());
+		}
+	}
+
+	public static void safeSetFullTime(String world, long fullTime) {
+		World w = Bukkit.getWorld(world);
+		if (w == null) return;
+		try {
+			w.setFullTime(fullTime);
+		} catch (IllegalArgumentException e) {
+			MsgHandler.debugMsg("Skipping setFullTime for §e" + world + "§b: " + e.getMessage());
+		}
 	}
 
 	/**

--- a/src/net/vdcraft/arvdc/timemanager/placeholders/PAPIHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/placeholders/PAPIHandler.java
@@ -220,7 +220,18 @@ public class PAPIHandler extends PlaceholderExpansion {
         if(identifier.equals(MainTM.PH_YYYY)){
 			return PlaceholdersHandler.replacePlaceholder("{" + MainTM.PH_PREFIX + identifier + "}", world, lang, player);
         }
- 
+
+        // %tm_serverday% — total whole days since the server's reference tick
+        // (kept across restarts via initialTickNb in config or MySQL). This is
+        // a server-wide counter, distinct from %tm_elapseddays% which is per
+        // world / based on World#getFullTime.
+        if(identifier.equals(MainTM.PH_SERVERDAY)){
+            long currentTick = net.vdcraft.arvdc.timemanager.mainclass.ValuesConverter.getServerTick();
+            long days = (currentTick - MainTM.getFirstEverTick()) / 24000L;
+            if (days < 0) days = 0;
+            return String.valueOf(days);
+        }
+
         // We return null if an invalid placeholder (f.e. %someplugin_placeholder3%) was provided
         return null;
     }

--- a/src/net/vdcraft/arvdc/timemanager/placeholders/PlaceholdersHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/placeholders/PlaceholdersHandler.java
@@ -136,6 +136,14 @@ public class PlaceholdersHandler extends MainTM {
 		case "{" + PH_PREFIX + PH_YYYY + "}" :
 			return ValuesConverter.dateFromElapsedDays(ed, "yyyy");
 
+		// Returns the server-wide elapsed days since TimeManager was first
+		// installed (firstEverTickNb, written once on first enable and never
+		// reset). Independent of the resetOnStartup behaviour for initialTick.
+		case "{" + PH_PREFIX + PH_SERVERDAY + "}" :
+			long serverDays = (ValuesConverter.getServerTick() - MainTM.getFirstEverTick()) / 24000L;
+			if (serverDays < 0) serverDays = 0;
+			return String.valueOf(serverDays);
+
 		default :
 			return placeholder;
 		}


### PR DESCRIPTION
## Summary

This PR is a feature-and-fix bundle on top of 1.12.1. Everything is opt-in or non-breaking; existing configs keep working.

### Bug fix
- `setTime` / `setFullTime` calls in `SyncHandler`, `SpeedHandler`, `SleepHandler` are wrapped in new `SyncHandler.safeSetTime` / `safeSetFullTime` helpers that catch the Paper `IllegalArgumentException("Cannot set time in world without world clock")`. Datapack dimensions, `/tick freeze`, and frozen-speed worlds no longer spam the console or kill the scheduler task on first throw.
- `worldSync` skips `setTime` entirely when the target world is already at the desired tick and frozen (no-op anyway).

### New per-world config: `lock-time`
Single-key shortcut for "freeze this world at time X" or "follow real UTC time". Accepts named presets (`noon`, `dawn`, `dusk`, `midnight`, `day`, `night`, etc.), raw ticks `0-23999`, `HH:mm`, `realtime`, or `false`. Plugin internally rewrites `start`, `daySpeed`, `nightSpeed` and `firstStartTime`; `lock-time` stays in the config as source of truth.

### New `/tm` subcommands
- `/tm lock <world> [time|here|realtime]` — write `lock-time` and apply at runtime
- `/tm unlock <world>` — clear `lock-time`
- `/tm animation <world> [on|off|toggle|instant]` — flip `nightSkipMode`
- `/tm placeholders` — print every placeholder (PAPI form `%tm_X%` and in-message `{tm_X}`)
- `/tm hud [on|off|toggle]` — per-player ActionBar opt-in
- `/tm nowitem [player]` — give a Pocket Watch CLOCK item that runs `/now` on right-click
- `/tm help` now renders a colored grouped list (Inspection / Run-time / Configuration) inside the plugin instead of falling back to plugin.yml's plain-text usage block
- Tab completion + dispatch wired up for every new subcommand

### New placeholder: `%tm_serverday%`
Server-wide elapsed days, persists across restarts. Backed by a new `initialTick.firstEverTickNb` key written once on first enable and never reset — independent of `resetOnStartup`. Public `MainTM.getInitialTick()` / `MainTM.getFirstEverTick()` accessors added so external integrations don't need protected-field access.

### New features
- **Refreshing signs** — place a sign with `[tm]` on the first line (marker configurable); next 3 lines accept `{tm_*}` placeholders. Plugin redraws on a configurable interval; coordinates persist to `signs.yml`. Permission: `timemanager.signs.create`.
- **Pocket-watch /now item** — custom CLOCK with PDC marker (`timemanager:now-item`). Right-click triggers `/now` with a configurable cooldown. Permission: `timemanager.now-item.use`.
- **ActionBar HUD** — optional, disabled by default (`hud.actionbar.enabled: false`). When enabled, broadcasts a `{tm_*}` format to every online player at a configurable interval. Players opt out per-account with `/tm hud off`.
- **Enhanced sleep particles** — adds END_ROD / GLOW / FIREWORK layers on top of the existing `DUST_COLOR_TRANSITION` per animation phase. Toggle with `sleep.enhanced-particles: false` to keep the old look.
- **defNightSkipMode default changed to `animation`** so newly added worlds get the particle show out of the box. Existing worlds are not touched.

### Docs
- `README.md`: "What's new in 1.12.2" CHANGELOG section
- `config-header.txt`: full documentation for `lock-time`, `signs`, `now-item`, `hud.actionbar`, `sleep.enhanced-particles`
- `plugin.yml`: 6 new subcommand usage lines, 3 new permission nodes (`timemanager.signs.create`, `timemanager.now-item.use`, `timemanager.hud.toggle`)

## Backwards compatibility
- Clean install on a server with no existing TimeManager config — defaults write correctly, no exceptions.
- Hot reload (`/tm reload`) on an existing 1.12.1 config — defaults for the new sections are added, existing values preserved.
- `MainTM.initialTick` field is still `protected static` (was briefly `public` during development, reverted before commit).
- Existing worlds' `nightSkipMode` is preserved (admin override safety). New worlds get `animation` by default.

## Test plan
- [x] Build (`mvn clean package`) succeeds
- [x] Clean install (deleted plugin folder, restarted) — writes defaults, no exception
- [x] `/tm reload` over existing 1.12.1 config — no data loss, new sections appear
- [x] `/tm lock Spawn noon` + `/tm unlock Spawn` — flips lock-time, applies speed/start changes
- [x] `/tm placeholders` — lists 23 placeholders
- [x] `/tm hud on` toggles the per-player opt-in
- [x] `/tm nowitem` gives a CLOCK; right-click triggers `/now`
- [x] `[tm]` sign with `{tm_time24}` + `{tm_serverday}` + `{tm_dayname}` refreshes correctly and survives restart
- [x] Sleep animation in a world with `nightSkipMode: animation` shows the enhanced particle layers
- [x] Pre-existing exception from `setTime` is gone (Spawn world frozen at noon, no console spam)

## Notes / possible follow-ups
- New hard-coded English messages (e.g. "Locked X at Y") aren't in `lang.yml` yet — left for a follow-up i18n pass.
- Existing-worlds migration for `nightSkipMode: default → animation` is intentionally NOT automatic to preserve admin overrides. Documented in README.