### PR TITLE
Fix tabs in plugin.yml so it parses

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -74,7 +74,7 @@ commands:
             /<command> set playerOffset [-23999 → 23999] [all|player]
             /<command> set playerTime [ticks|daypart|HH:mm:ss|reset] [all|player]
             /<command> set refreshRate [ticks]
-			/<command> set sleepAnimation [on|off|toggle|instant] [all|world]
+            /<command> set sleepAnimation [on|off|toggle|instant] [all|world]
             /<command> set sleep [true|false] [all|world]
             /<command> set speed [0.0 → 20.0] [all|world]
             /<command> set speedDay [0.0 → 20.0] [all|world]


### PR DESCRIPTION
Line 77 of plugin.yml uses 3 tabs instead of 12 spaces for the indentation of the sleepAnimation entry. SnakeYAML (which Bukkit uses to parse plugin.yml) does not accept tab characters for indentation, so this file fails to parse at server startup with a ScannerError, and the plugin never gets loaded (Bukkit throws InvalidDescriptionException).

The build itself passes because Maven does not validate plugin.yml at compile time, so the regression is invisible until you actually drop the jar into a server.

Verified locally that yaml.safe_load fails on the current master file and succeeds after the fix.

Repro:
```
unzip -p target/TimeManager-2.0.1-b.jar plugin.yml | python3 -c 'import sys,yaml; yaml.safe_load(sys.stdin)'
```