### PR TITLE
Fix infinite warning loop from /tm set playerTime (fixes #52)

### DIFF
--- a/src/net/vdcraft/arvdc/timemanager/AdminCmdExecutor.java
+++ b/src/net/vdcraft/arvdc/timemanager/AdminCmdExecutor.java
@@ -355,7 +355,7 @@ public class AdminCmdExecutor implements CommandExecutor {
 			}
 		}
 		// Set time offset for player(s)
-		if (nbArgs >= 2) {
+		if (nbArgs >= 2 && args[0].equalsIgnoreCase(MainTM.CMD_SET)) {
 			if (args[1].equalsIgnoreCase(MainTM.CMD_SET_PLAYEROFFSET)) {
 				if (((nbArgs < 4) && !(sender instanceof Player)) || ((nbArgs < 3) && (sender instanceof Player))) {
 					MsgHandler.cmdErrorMsg(sender, MainTM.missingArgMsg, MainTM.CMD_SET + " " + MainTM.CMD_SET_PLAYEROFFSET); // Send error and help msg

--- a/src/net/vdcraft/arvdc/timemanager/mainclass/MsgHandler.java
+++ b/src/net/vdcraft/arvdc/timemanager/mainclass/MsgHandler.java
@@ -44,7 +44,7 @@ public class MsgHandler extends MainTM {
 	public static void cmdErrorMsg(CommandSender sender, String msgError, String cmdHelp) {
 		playerAdminMsg(sender, ChatColor.RED + msgError); // Player error msg (in case is player)
 		warnMsg(msgError); // Console error msg (always)
-		Bukkit.dispatchCommand(sender, CMD_TM + " " + CMD_HELP + cmdHelp); // Sender help msg (always)
+		Bukkit.dispatchCommand(sender, CMD_TM + " " + CMD_HELP + " " + cmdHelp); // Sender help msg (always)
 	}
 
 	/**


### PR DESCRIPTION
Fixes #52.

## Root cause

Two independent bugs chain together to produce the infinite loop
reported in the issue.

**Bug 1**: Missing space in \`MsgHandler.cmdErrorMsg\` (line 47).

\`\`\`java
Bukkit.dispatchCommand(sender, CMD_TM + " " + CMD_HELP + cmdHelp);
\`\`\`

\`CMD_HELP\` is \`"help"\` (no trailing space) and \`cmdHelp\` values are
things like \`"set playerTime"\`. The dispatched command becomes
\`tm helpset playerTime\` instead of \`tm help set playerTime\`.

**Bug 2**: Missing \`args[0]\` guard in \`AdminCmdExecutor\` (line 358).

The block that handles \`set playerOffset\` / \`set playerTime\` only checks
\`args[1]\`. It's outside the \`args[0] == CMD_SET\` branch, so it matches
on any first argument as long as the second argument is \`playerTime\`
or \`playerOffset\`.

## How they chain

1. Player runs \`/tm set playerTime\` (nbArgs=2).
2. \`cmdErrorMsg\` fires and dispatches the malformed \`tm helpset playerTime\`.
3. \`args[0]="helpset"\` matches nothing, but the unguarded block at line 358
   picks it up because \`args[1]="playerTime"\`.
4. It sees nbArgs<3 and calls \`cmdErrorMsg\` with the same \`cmdHelp\`.
5. Goto 2. Console spams ~20k msg/s and the server thread blocks.

Same trigger applies to \`/tm set playerOffset\`.

## Fix

* \`MsgHandler.java:47\`: add the missing space:
  \`CMD_TM + " " + CMD_HELP + " " + cmdHelp\`
* \`AdminCmdExecutor.java:358\`: nest the block inside
  \`args[0].equalsIgnoreCase(CMD_SET)\` so it can't fire from a stray
  first argument.

Either fix alone breaks the loop, but both are real bugs; applying
both prevents similar recursions if another \`cmdErrorMsg\` call site
ever passes a \`cmdHelp\` value whose second word matches these
handlers.